### PR TITLE
add candidate task pipeline foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ scripts/curation-pipeline/worker-assignments/
 scripts/curation-pipeline/new-apps.json
 scripts/curation-pipeline/generated-tasks.json
 scripts/curation-pipeline/curated-tasks-new.json
+prisma/scripts/task-curation/istaken-audit-report.json
+prisma/scripts/task-curation/backfill-candidate-tasks-report.json
+prisma/scripts/task-curation/import-curated-report.json
 
 # worker onboarding materials (kept locally, not for repo)
 /onboarding_materials/

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,12 @@ type AppMetadata {
   url         String?
 }
 
+type CandidateTask {
+  description String
+  generated   Boolean @default(false)
+  status      String  @default("open")
+}
+
 model App {
   id               String            @id @default(auto()) @map("_id") @db.ObjectId
   v                Int               @default(0) @map("__v")
@@ -76,11 +82,11 @@ model App {
 }
 
 model CandidateTaskApp {
-  id             String   @id @default(auto()) @map("_id") @db.ObjectId
-  appId          String   @unique @map("app") @db.ObjectId
-  app            App      @relation(fields: [appId], references: [id])
-  candidateTasks String[]
-  isTaken        Boolean
+  id      String          @id @default(auto()) @map("_id") @db.ObjectId
+  appId   String          @unique @map("app") @db.ObjectId
+  app     App             @relation(fields: [appId], references: [id])
+  tasks   CandidateTask[]
+  isTaken Boolean
 
   @@map("candidate_task_apps")
 }

--- a/prisma/scripts/task-curation/audit-istaken.mjs
+++ b/prisma/scripts/task-curation/audit-istaken.mjs
@@ -11,18 +11,19 @@
  *   under-marked          isTaken=false, HAS evidence   → should be true (risk: re-issued)
  *   over-marked           isTaken=true,  NO evidence     → review (maybe reserved/stale)
  *
- * Default is a read-only dry run. With --apply, ONLY under-marked apps are
- * flipped false→true (the safe direction); over-marked apps are never changed
- * automatically. Only the isTaken field is written — candidateTasks is untouched.
+ * Default is a read-only dry run. With --apply, under-marked apps are flipped
+ * false→true. With --apply --release-over-marked, over-marked apps are also
+ * flipped true→false. Only the isTaken field is written.
  *
  * Usage:
  *   dotenvx run --env-file=.env.local -- node prisma/scripts/task-curation/audit-istaken.mjs
  *   dotenvx run --env-file=.env.local -- node prisma/scripts/task-curation/audit-istaken.mjs --apply
  *
  * Options:
- *   --apply        Flip under-marked apps (false→true). Default: dry run.
- *   --out <path>   Report JSON path (default: <script-dir>/istaken-audit-report.json)
- *   -h, --help     Show this message
+ *   --apply                Flip under-marked apps (false→true). Default: dry run.
+ *   --release-over-marked  With --apply, also flip over-marked apps true→false.
+ *   --out <path>           Report JSON path (default: <script-dir>/istaken-audit-report.json)
+ *   -h, --help             Show this message
  *
  * DATABASE_URL must be set (same connection string as the app).
  */
@@ -40,6 +41,7 @@ const { values } = parseArgs({
   args: process.argv.slice(2),
   options: {
     apply: { type: "boolean", default: false },
+    "release-over-marked": { type: "boolean", default: false },
     out: { type: "string" },
     help: { type: "boolean", short: "h" },
   },
@@ -50,11 +52,14 @@ if (values.help) {
   console.log(`Usage: node prisma/scripts/task-curation/audit-istaken.mjs [options]
 
 Options:
-  --apply        Flip under-marked apps (isTaken false→true). Default: dry run.
-  --out <path>   Report JSON path (default: <script-dir>/istaken-audit-report.json)
-  -h, --help     Show this message`);
+  --apply                Flip under-marked apps (isTaken false→true). Default: dry run.
+  --release-over-marked  With --apply, also flip over-marked apps true→false.
+  --out <path>           Report JSON path (default: <script-dir>/istaken-audit-report.json)
+  -h, --help             Show this message`);
   process.exit(0);
 }
+
+const releaseOverMarked = values["release-over-marked"];
 
 const outputPath = path.resolve(
   process.cwd(),
@@ -136,12 +141,18 @@ async function main() {
     }
   };
   preview("UNDER-marked — would be flipped to isTaken=true", buckets.underMarked);
-  preview("OVER-marked — flagged for manual review (NOT changed)", buckets.overMarked);
+  preview(
+    releaseOverMarked
+      ? "OVER-marked — would be flipped to isTaken=false"
+      : "OVER-marked — flagged for manual review (NOT changed)",
+    buckets.overMarked,
+  );
 
   const report = {
     generatedAt: new Date().toISOString(),
     rule: "taken if captureCount > 0 OR traceCount > 0",
     applied: values.apply,
+    releaseOverMarked,
     totals: {
       apps: total,
       consistentTaken: buckets.consistentTaken.length,
@@ -155,22 +166,41 @@ async function main() {
   await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
   console.log(`\nFull report → ${outputPath}`);
 
-  // ── Apply (under-marked only) ───────────────────────────────────────────────
+  // ── Apply ─────────────────────────────────────────────────────────────────
   if (!values.apply) {
-    console.log(`\nDry run — no changes written. Re-run with --apply to flip ${buckets.underMarked.length} under-marked apps to isTaken=true.`);
+    const releaseHint = buckets.overMarked.length
+      ? " Add --release-over-marked to also flip over-marked apps to isTaken=false."
+      : "";
+    console.log(`\nDry run — no changes written. Re-run with --apply to flip ${buckets.underMarked.length} under-marked apps to isTaken=true.${releaseHint}`);
     return;
   }
-  if (buckets.underMarked.length === 0) {
-    console.log(`\n--apply: nothing to fix; no under-marked apps.`);
-    return;
+
+  let underMarkedUpdated = 0;
+  if (buckets.underMarked.length > 0) {
+    const ids = buckets.underMarked.map((r) => r.id);
+    const result = await prisma.candidateTaskApp.updateMany({
+      where: { id: { in: ids } },
+      data: { isTaken: true },
+    });
+    underMarkedUpdated = result.count;
   }
-  const ids = buckets.underMarked.map((r) => r.id);
-  const result = await prisma.candidateTaskApp.updateMany({
-    where: { id: { in: ids } },
-    data: { isTaken: true },
-  });
-  console.log(`\n--apply: flipped ${result.count} under-marked apps to isTaken=true (candidateTasks untouched).`);
-  console.log(`Over-marked apps left unchanged: ${buckets.overMarked.length} (review manually).`);
+
+  let overMarkedUpdated = 0;
+  if (releaseOverMarked && buckets.overMarked.length > 0) {
+    const ids = buckets.overMarked.map((r) => r.id);
+    const result = await prisma.candidateTaskApp.updateMany({
+      where: { id: { in: ids } },
+      data: { isTaken: false },
+    });
+    overMarkedUpdated = result.count;
+  }
+
+  console.log(`\n--apply: flipped ${underMarkedUpdated} under-marked apps to isTaken=true.`);
+  if (releaseOverMarked) {
+    console.log(`--apply --release-over-marked: flipped ${overMarkedUpdated} over-marked apps to isTaken=false.`);
+  } else {
+    console.log(`Over-marked apps left unchanged: ${buckets.overMarked.length}. Re-run with --apply --release-over-marked to release them.`);
+  }
 }
 
 main()

--- a/prisma/scripts/task-curation/backfill-candidate-tasks.mjs
+++ b/prisma/scripts/task-curation/backfill-candidate-tasks.mjs
@@ -1,0 +1,220 @@
+/**
+ * backfill-candidate-tasks.mjs - Convert legacy candidateTasks strings to tasks objects.
+ *
+ * This backfills CandidateTaskApp rows that still have:
+ *   candidateTasks: ["..."]
+ *
+ * into:
+ *   tasks: [{ description, generated: false, status: "open" }]
+ *
+ * Backfilled "open" is candidate-list state only. It does not mean the task
+ * was never historically copied into a Capture/Task, because legacy data did
+ * not store a durable candidate-task origin link.
+ *
+ * Apps present in the curated import are skipped by default so
+ * import-curated-tasks.mjs can write their true generated provenance.
+ *
+ * Usage:
+ *   dotenvx run --env-file=.env.local -- node prisma/scripts/task-curation/backfill-candidate-tasks.mjs
+ *   dotenvx run --env-file=.env.local -- node prisma/scripts/task-curation/backfill-candidate-tasks.mjs --apply
+ *
+ * Options:
+ *   --curated <path>  Curated JSON whose appIds should be skipped
+ *                     (default: scripts/curation-pipeline/candidate-task-apps-export-curated.json)
+ *   --out <path>      Report JSON path (default: <script-dir>/backfill-candidate-tasks-report.json)
+ *   --apply           Write changes. Default: dry run.
+ *   -h, --help        Show this message
+ *
+ * DATABASE_URL must be set (same connection string as the app).
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    curated: { type: "string" },
+    out: { type: "string" },
+    apply: { type: "boolean", default: false },
+    help: { type: "boolean", short: "h" },
+  },
+  allowPositionals: false,
+});
+
+if (values.help) {
+  console.log(`Usage: node prisma/scripts/task-curation/backfill-candidate-tasks.mjs [options]
+
+Options:
+  --curated <path>  Curated JSON whose appIds should be skipped.
+  --out <path>      Report JSON path.
+  --apply           Write changes. Default: dry run.
+  -h, --help        Show this message`);
+  process.exit(0);
+}
+
+const curatedPath = path.resolve(
+  process.cwd(),
+  values.curated ??
+    path.join(repoRoot, "scripts/curation-pipeline/candidate-task-apps-export-curated.json"),
+);
+const outputPath = path.resolve(
+  process.cwd(),
+  values.out ?? path.join(__dirname, "backfill-candidate-tasks-report.json"),
+);
+
+function objectIdToString(value) {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && typeof value.$oid === "string") {
+    return value.$oid;
+  }
+  if (value && typeof value === "object" && typeof value.toHexString === "function") {
+    return value.toHexString();
+  }
+  return null;
+}
+
+function toBackfilledTasks(candidateTasks) {
+  return candidateTasks
+    .filter((task) => typeof task === "string" && task.trim().length > 0)
+    .map((task) => ({
+      description: task.trim(),
+      generated: false,
+      status: "open",
+    }));
+}
+
+async function loadCuratedAppIds() {
+  const raw = JSON.parse(await readFile(curatedPath, "utf8"));
+  const entries = Array.isArray(raw) ? raw : raw.records;
+  if (!Array.isArray(entries)) {
+    throw new Error("Curated JSON must be an array or an object with a records array.");
+  }
+  return new Set(
+    entries
+      .map((entry) => entry.appId ?? entry.id)
+      .filter((appId) => typeof appId === "string" && appId.length > 0),
+  );
+}
+
+async function main() {
+  const curatedAppIds = await loadCuratedAppIds();
+  console.log(`Loaded ${curatedAppIds.size} curated appIds from ${curatedPath}.`);
+
+  const rows = await prisma.candidateTaskApp.findRaw({
+    options: {
+      projection: { _id: 1, app: 1, tasks: 1, candidateTasks: 1 },
+    },
+  });
+
+  const plan = {
+    willBackfill: [],
+    skippedCurated: [],
+    alreadyBackfilled: [],
+    emptyLegacyTasks: [],
+    invalidId: [],
+  };
+
+  for (const row of rows) {
+    const id = objectIdToString(row._id);
+    const appId = objectIdToString(row.app);
+    if (!id || !appId) {
+      plan.invalidId.push({ id, appId });
+      continue;
+    }
+
+    if (curatedAppIds.has(appId)) {
+      plan.skippedCurated.push({ id, appId });
+      continue;
+    }
+
+    if (Array.isArray(row.tasks) && row.tasks.length > 0) {
+      plan.alreadyBackfilled.push({ id, appId });
+      continue;
+    }
+
+    const legacyTasks = Array.isArray(row.candidateTasks) ? row.candidateTasks : [];
+    const tasks = toBackfilledTasks(legacyTasks);
+    if (tasks.length === 0) {
+      plan.emptyLegacyTasks.push({ id, appId });
+      continue;
+    }
+
+    plan.willBackfill.push({
+      id,
+      appId,
+      fromCount: legacyTasks.length,
+      toCount: tasks.length,
+      tasks,
+    });
+  }
+
+  console.log(`\nBackfill plan - ${rows.length} CandidateTaskApp rows`);
+  console.log(`  will backfill      : ${plan.willBackfill.length}`);
+  console.log(`  skipped curated    : ${plan.skippedCurated.length}`);
+  console.log(`  already backfilled : ${plan.alreadyBackfilled.length}`);
+  console.log(`  empty legacy tasks : ${plan.emptyLegacyTasks.length}`);
+  console.log(`  invalid ids        : ${plan.invalidId.length}`);
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    curated: curatedPath,
+    applied: values.apply,
+    totals: {
+      rows: rows.length,
+      willBackfill: plan.willBackfill.length,
+      skippedCurated: plan.skippedCurated.length,
+      alreadyBackfilled: plan.alreadyBackfilled.length,
+      emptyLegacyTasks: plan.emptyLegacyTasks.length,
+      invalidId: plan.invalidId.length,
+    },
+    willBackfill: plan.willBackfill,
+    emptyLegacyTasks: plan.emptyLegacyTasks,
+    invalidId: plan.invalidId,
+  };
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  console.log(`\nFull report -> ${outputPath}`);
+
+  if (!values.apply) {
+    console.log(`\nDry run - no changes written. Re-run with --apply to backfill ${plan.willBackfill.length} apps.`);
+    return;
+  }
+
+  let done = 0;
+  for (const item of plan.willBackfill) {
+    await prisma.$runCommandRaw({
+      update: "candidate_task_apps",
+      updates: [
+        {
+          q: { _id: { $oid: item.id } },
+          u: {
+            $set: { tasks: item.tasks },
+            $unset: { candidateTasks: "" },
+          },
+          multi: false,
+        },
+      ],
+    });
+    done += 1;
+    if (done % 200 === 0) console.log(`  updated ${done}/${plan.willBackfill.length}`);
+  }
+
+  console.log(`\n--apply: backfilled ${done} apps.`);
+}
+
+main()
+  .catch((error) => {
+    console.error("Candidate-task backfill failed.");
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/prisma/scripts/task-curation/import-curated-tasks.mjs
+++ b/prisma/scripts/task-curation/import-curated-tasks.mjs
@@ -2,17 +2,17 @@
  * import-curated-tasks.mjs — Write curated tasks back into CandidateTaskApp.
  *
  * Reads a curated JSON array (output of curate_tasks.py / curate_db_apps.py,
- * after filtering) and updates each matching CandidateTaskApp's candidateTasks
- * to the curated `selected` task strings.
+ * after filtering) and updates each matching CandidateTaskApp's tasks to the
+ * curated `selected` tasks.
  *
- * IMPORTANT: only the candidateTasks field is written. isTaken is never
+ * IMPORTANT: only the tasks field is written. isTaken is never
  * touched — reconciling isTaken is the job of audit-istaken.mjs.
  *
  * Matching: by appId (App._id), which is @unique on CandidateTaskApp. Entries
  * whose appId has no CandidateTaskApp are reported as unmatched and skipped.
  *
  * Curated entry shape (only these fields are used):
- *   { "appId": str, "appName": str, "selected": [ { "task": str, ... } ] }
+ *   { "appId": str, "appName": str, "selected": [ { "task": str, "generated": bool } ] }
  *
  * Usage:
  *   dotenvx run --env-file=.env.local -- node prisma/scripts/task-curation/import-curated-tasks.mjs --in <file>
@@ -67,15 +67,81 @@ const outputPath = path.resolve(
 // MongoDB ObjectId — 24 hex chars. Guards against malformed appIds blowing up
 // the unique-where lookup.
 const OBJECT_ID_RE = /^[a-f0-9]{24}$/i;
+const VALID_STATUSES = new Set(["open", "started", "hidden"]);
+
+function objectIdToString(value) {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && typeof value.$oid === "string") {
+    return value.$oid;
+  }
+  if (value && typeof value === "object" && typeof value.toHexString === "function") {
+    return value.toHexString();
+  }
+  return null;
+}
 
 function tasksFromEntry(entry) {
   return (entry.selected ?? [])
-    .map((s) => (typeof s === "string" ? s : s?.task))
-    .filter((t) => typeof t === "string" && t.trim().length > 0);
+    .map((selected) => {
+      const description = typeof selected === "string" ? selected : selected?.task;
+      if (typeof description !== "string" || description.trim().length === 0) {
+        return null;
+      }
+      return {
+        description: description.trim(),
+        generated: typeof selected === "object" ? selected.generated === true : false,
+        status: "open",
+      };
+    })
+    .filter(Boolean);
 }
 
 function sameTasks(a, b) {
-  return a.length === b.length && a.every((t, i) => t === b[i]);
+  return (
+    a.length === b.length &&
+    a.every(
+      (task, i) =>
+        task.description === b[i].description &&
+        task.generated === b[i].generated &&
+        task.status === b[i].status,
+    )
+  );
+}
+
+function normalizeExistingTask(task) {
+  if (typeof task === "string") {
+    return { description: task.trim(), generated: false, status: "open" };
+  }
+  if (!task || typeof task !== "object" || typeof task.description !== "string") {
+    return null;
+  }
+  return {
+    description: task.description.trim(),
+    generated: task.generated === true,
+    status: VALID_STATUSES.has(task.status) ? task.status : "open",
+  };
+}
+
+function normalizeExistingTasks(row) {
+  const source = Array.isArray(row.tasks)
+    ? row.tasks
+    : Array.isArray(row.candidateTasks)
+      ? row.candidateTasks
+      : [];
+  return source.map(normalizeExistingTask).filter(Boolean);
+}
+
+function preserveCurrentStatuses(currentTasks, importedTasks) {
+  const byKey = new Map(
+    currentTasks.map((task) => [
+      `${task.description}\u0000${task.generated ? "1" : "0"}`,
+      task.status,
+    ]),
+  );
+  return importedTasks.map((task) => ({
+    ...task,
+    status: byKey.get(`${task.description}\u0000${task.generated ? "1" : "0"}`) ?? "open",
+  }));
 }
 
 async function main() {
@@ -86,12 +152,30 @@ async function main() {
   }
   console.log(`Loaded ${entries.length} curated entries from ${inputPath}.`);
 
-  // Preload existing CandidateTaskApp rows so we can diff and detect unmatched
-  // appIds without a per-entry round trip.
-  const existing = await prisma.candidateTaskApp.findMany({
-    select: { id: true, appId: true, candidateTasks: true },
+  // Raw read keeps the importer usable before/after the legacy candidateTasks
+  // field is removed from Prisma's typed schema.
+  const existing = await prisma.candidateTaskApp.findRaw({
+    options: {
+      projection: { _id: 1, app: 1, tasks: 1, candidateTasks: 1 },
+    },
   });
-  const byAppId = new Map(existing.map((c) => [c.appId, c]));
+  const byAppId = new Map(
+    existing
+      .map((row) => {
+        const appId = objectIdToString(row.app);
+        const id = objectIdToString(row._id);
+        if (!appId || !id) return null;
+        return [
+          appId,
+          {
+            id,
+            appId,
+            tasks: normalizeExistingTasks(row),
+          },
+        ];
+      })
+      .filter(Boolean),
+  );
 
   const plan = { willUpdate: [], unchanged: [], unmatched: [], empty: [], invalidId: [] };
 
@@ -102,8 +186,8 @@ async function main() {
       plan.invalidId.push({ appId: appId ?? null, appName });
       continue;
     }
-    const tasks = tasksFromEntry(entry);
-    if (tasks.length === 0) {
+    const importedTasks = tasksFromEntry(entry);
+    if (importedTasks.length === 0) {
       plan.empty.push({ appId, appName });
       continue;
     }
@@ -112,14 +196,15 @@ async function main() {
       plan.unmatched.push({ appId, appName });
       continue;
     }
-    if (sameTasks(current.candidateTasks, tasks)) {
+    const tasks = preserveCurrentStatuses(current.tasks, importedTasks);
+    if (sameTasks(current.tasks, tasks)) {
       plan.unchanged.push({ appId, appName });
     } else {
       plan.willUpdate.push({
         id: current.id,
         appId: String(appId),
         appName,
-        fromCount: current.candidateTasks.length,
+        fromCount: current.tasks.length,
         toCount: tasks.length,
         tasks,
       });
@@ -179,12 +264,12 @@ async function main() {
   for (const u of plan.willUpdate) {
     await prisma.candidateTaskApp.update({
       where: { appId: u.appId },
-      data: { candidateTasks: u.tasks }, // isTaken intentionally omitted
+      data: { tasks: u.tasks }, // isTaken intentionally omitted
     });
     done += 1;
     if (done % 200 === 0) console.log(`  …updated ${done}/${plan.willUpdate.length}`);
   }
-  console.log(`\n--apply: updated candidateTasks for ${done} apps (isTaken untouched).`);
+  console.log(`\n--apply: updated tasks for ${done} apps (isTaken untouched).`);
 }
 
 main()

--- a/scripts/curation-pipeline/curate_tasks.py
+++ b/scripts/curation-pipeline/curate_tasks.py
@@ -231,7 +231,17 @@ def build_prompt(entry: dict) -> str:
     name = meta.get("name", "Unknown App")
     category = entry["app"].get("category", {}).get("name", "Unknown")
     description = (meta.get("description") or "")[:2000]
-    candidates = entry.get("candidateTasks", [])
+    candidates = [
+        task.get("description", "").strip()
+        for task in entry.get("tasks", [])
+        if isinstance(task, dict) and task.get("description", "").strip()
+    ]
+    if not candidates:
+        candidates = [
+            task.strip()
+            for task in entry.get("candidateTasks", [])
+            if isinstance(task, str) and task.strip()
+        ]
 
     if candidates:
         candidate_list = "\n".join(f"  {i+1}. {t}" for i, t in enumerate(candidates))

--- a/scripts/curation-pipeline/import_new_app_candidates.py
+++ b/scripts/curation-pipeline/import_new_app_candidates.py
@@ -178,9 +178,12 @@ def run_import(
             continue
 
         candidates_col.insert_one({
-            "app":            app_object_id,
-            "candidateTasks": task_strings,
-            "isTaken":        False,
+            "app": app_object_id,
+            "tasks": [
+                {"description": task, "generated": False, "status": "open"}
+                for task in task_strings
+            ],
+            "isTaken": False,
         })
         inserted_cands += 1
         print(f"  [imported] {name} | {len(task_strings)} tasks")

--- a/scripts/curation-pipeline/run_pipeline.sh
+++ b/scripts/curation-pipeline/run_pipeline.sh
@@ -2,10 +2,11 @@
 # run_pipeline.sh — Full task curation and worker assignment pipeline.
 #
 # Steps:
-#   1. Curate all apps in candidate-task-apps-export.json (resumes from existing work)
-#   2. Clean up tasks (placeholder emails + length > 75 chars)
-#   3. Assign apps to workers (fresh reshuffle)
-#   4. Export worker PDFs
+#   1. Filter exported apps (remove taken apps + Games)
+#   2. Curate filtered apps (resumes from existing work)
+#   3. Clean up tasks (placeholder emails + length > 75 chars)
+#   4. Assign apps to workers (fresh reshuffle)
+#   5. Export worker PDFs
 #
 # Usage:
 #   ./run_pipeline.sh
@@ -14,7 +15,9 @@
 set -euo pipefail
 
 WORKSPACE="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$WORKSPACE/../.." && pwd)"
 EXPORT="$WORKSPACE/candidate-task-apps-export.json"
+FILTERED="$WORKSPACE/candidate-task-apps-filtered.json"
 CURATED="$WORKSPACE/candidate-task-apps-export-curated.json"
 EXISTING="$WORKSPACE/curated-tasks.json"
 ASSIGNMENTS="$WORKSPACE/worker-assignments"
@@ -37,8 +40,15 @@ if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
   exit 1
 fi
 
-# ── Step 1 — Curate ────────────────────────────────────────────────────────
-log "STEP 1 — Curating tasks from full export"
+# ── Step 1 — Filter ────────────────────────────────────────────────────────
+log "STEP 1 — Filtering candidate apps"
+
+node "$REPO_ROOT/prisma/scripts/task-curation/filter-candidate-task-apps.mjs" \
+  --in  "$EXPORT" \
+  --out "$FILTERED"
+
+# ── Step 2 — Curate ────────────────────────────────────────────────────────
+log "STEP 2 — Curating tasks from filtered export"
 
 # Seed the new output file with any existing curated work so --resume can skip it.
 if [ -f "$EXISTING" ] && [ ! -f "$CURATED" ]; then
@@ -49,27 +59,27 @@ elif [ ! -f "$CURATED" ]; then
 fi
 
 python3 "$WORKSPACE/curate_tasks.py" \
-  --input  "$EXPORT" \
+  --input  "$FILTERED" \
   --output "$CURATED" \
   --resume \
   $CURATE_ARGS
 
-# ── Step 2 — Cleanup ───────────────────────────────────────────────────────
-log "STEP 2 — Cleaning up tasks (emails + length)"
+# ── Step 3 — Cleanup ───────────────────────────────────────────────────────
+log "STEP 3 — Cleaning up tasks (emails + length)"
 
 python3 "$WORKSPACE/cleanup_tasks.py" \
   --input "$CURATED" \
   --apply
 
-# ── Step 3 — Assign ────────────────────────────────────────────────────────
-log "STEP 3 — Assigning apps to workers"
+# ── Step 4 — Assign ────────────────────────────────────────────────────────
+log "STEP 4 — Assigning apps to workers"
 
 python3 "$WORKSPACE/assign_tasks.py" \
   --input      "$CURATED" \
   --output-dir "$ASSIGNMENTS"
 
-# ── Step 4 — Export PDFs ───────────────────────────────────────────────────
-log "STEP 4 — Exporting worker PDFs"
+# ── Step 5 — Export PDFs ───────────────────────────────────────────────────
+log "STEP 5 — Exporting worker PDFs"
 
 python3 "$WORKSPACE/export_worker_pdfs.py" \
   --input-dir  "$ASSIGNMENTS" \
@@ -78,4 +88,5 @@ python3 "$WORKSPACE/export_worker_pdfs.py" \
 # ---------------------------------------------------------------------------
 log "DONE"
 echo "Curated tasks : $CURATED"
+echo "Filtered apps  : $FILTERED"
 echo "Assignments   : $ASSIGNMENTS"

--- a/src/app/(signed-in)/candidates/components/candidate-gallery.tsx
+++ b/src/app/(signed-in)/candidates/components/candidate-gallery.tsx
@@ -61,6 +61,10 @@ const CandidateGalleryAppCard = ({
 }) => {
   const [copyIcon, setCopyIcon] = useState<"copy" | "check">("copy");
   const { handleSetAppTaken } = useCandidateTask();
+  const taskDescriptions = candidateTaskApp.tasks.map(
+    (task) => task.description
+  );
+
   const handleCopy = (tasks: string[]) => {
     navigator.clipboard.writeText(tasks.join("\n"));
     setCopyIcon("check");
@@ -73,7 +77,7 @@ const CandidateGalleryAppCard = ({
     return copyIcon === "copy" ? (
       <Copy
         className="w-4 h-4 text-muted-foreground cursor-pointer"
-        onClick={() => handleCopy(candidateTaskApp.candidateTasks)}
+        onClick={() => handleCopy(taskDescriptions)}
       />
     ) : (
       <Check
@@ -107,7 +111,7 @@ const CandidateGalleryAppCard = ({
               variant="destructive"
               className="absolute -top-2 -right-2 h-5 w-5 rounded-full flex items-center justify-center text-xs p-0 font-bold shadow-lg z-10 bg-blue-500 text-white"
             >
-              {candidateTaskApp.candidateTasks.length}
+              {candidateTaskApp.tasks.length}
             </Badge>
           </div>
         </CollapsibleTrigger>
@@ -153,9 +157,9 @@ const CandidateGalleryAppCard = ({
             {handleCopyIcon()}
           </div>
           <ul className="list-disc list-inside">
-            {candidateTaskApp.candidateTasks.map((task, index) => (
+            {candidateTaskApp.tasks.map((task, index) => (
               <li className="text-xs text-muted-foreground mb-1" key={index}>
-                {task}
+                {task.description}
               </li>
             ))}
           </ul>

--- a/src/lib/actions/candidate-task-apps.ts
+++ b/src/lib/actions/candidate-task-apps.ts
@@ -3,12 +3,29 @@
 import { Prisma } from "@prisma/client";
 import { prisma } from "../prisma";
 import { ActionPayload } from "./types";
+import { z } from "zod";
 
 export type CandidateTaskApp = Prisma.CandidateTaskAppGetPayload<{
   include: {
     app: true;
   };
 }>;
+
+const ObjectIdSchema = z.string().regex(/^[a-f0-9]{24}$/i);
+
+const GetCandidateTaskAppsInputSchema = z.object({
+  isTaken: z.boolean(),
+  page: z.number().int().positive().default(1),
+  pageSize: z.number().int().positive().max(200).default(100),
+  search: z.string().default(""),
+  excludeGenres: z.array(z.string()).default([]),
+  selectedGenres: z.array(z.string()).default([]),
+});
+
+const SetCandidateTaskAppTakenStatusInputSchema = z.object({
+  id: ObjectIdSchema,
+  isTaken: z.boolean(),
+});
 
 /**
  * Fetches candidate task apps from the database.
@@ -37,24 +54,42 @@ export const getCandidateTaskApps = async ({
     currentPage: number;
   }>
 > => {
+  const parsedInput = GetCandidateTaskAppsInputSchema.safeParse({
+    isTaken,
+    page,
+    pageSize,
+    search,
+    excludeGenres,
+    selectedGenres,
+  });
+  if (!parsedInput.success) {
+    return {
+      ok: false,
+      message: "Invalid candidate task app query.",
+      data: null,
+    };
+  }
+
+  const input = parsedInput.data;
+
   try {
-    const skip = (page - 1) * pageSize;
+    const skip = (input.page - 1) * input.pageSize;
     const where: Prisma.CandidateTaskAppWhereInput = {
-      isTaken: isTaken,
+      isTaken: input.isTaken,
       app: {
         is: {
           metadata: {
             is: {
               name: {
-                contains: search.trim(),
+                contains: input.search.trim(),
                 mode: "insensitive",
               },
               genre: {
-                hasEvery: selectedGenres,
+                hasEvery: input.selectedGenres,
               },
               NOT: {
                 genre: {
-                  hasSome: excludeGenres,
+                  hasSome: input.excludeGenres,
                 },
               },
             },
@@ -68,7 +103,7 @@ export const getCandidateTaskApps = async ({
     const candidateTaskApps = await prisma.candidateTaskApp.findMany({
       where,
       skip,
-      take: pageSize,
+      take: input.pageSize,
       include: { app: true },
       orderBy: { id: "asc" },
     });
@@ -79,8 +114,8 @@ export const getCandidateTaskApps = async ({
       data: {
         candidateTaskApps,
         totalCount,
-        hasMore: skip + pageSize < totalCount,
-        currentPage: page,
+        hasMore: skip + input.pageSize < totalCount,
+        currentPage: input.page,
       },
     };
   } catch (error) {
@@ -100,8 +135,23 @@ export const setCandidateTaskAppTakenStatus = async ({
   id: string;
   isTaken: boolean;
 }): Promise<ActionPayload<{ totalCount: number }>> => {
+  const parsedInput = SetCandidateTaskAppTakenStatusInputSchema.safeParse({
+    id,
+    isTaken,
+  });
+  if (!parsedInput.success) {
+    return {
+      ok: false,
+      message: "Invalid candidate task app taken status input.",
+      data: null,
+    };
+  }
+
   try {
-    await prisma.candidateTaskApp.update({ where: { id }, data: { isTaken } });
+    await prisma.candidateTaskApp.update({
+      where: { id: parsedInput.data.id },
+      data: { isTaken: parsedInput.data.isTaken },
+    });
     const totalCount = await prisma.candidateTaskApp.count({
       where: { isTaken: false },
     });


### PR DESCRIPTION
schema moved from candidateTasks to structured tasks

- backfill/import scripts support the new shape

- ai generated/scraped label is preserved

- script filter wiring is fixed

- current existing candidate UI compiles against tasks[]
