### PR TITLE
redesign candidate task browsing interface

### DIFF
--- a/src/app/(signed-in)/candidates/candidates-client.tsx
+++ b/src/app/(signed-in)/candidates/candidates-client.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { RefreshCcw } from "lucide-react";
+import { CandidateTaskGallery } from "./components/candidate-gallery";
+import { CandidateTaskSearch } from "./components/candidate-search";
+import {
+  CandidateTaskProvider,
+  useCandidateTask,
+} from "@/app/(signed-in)/candidates/components/candidate-task-context";
+import { useState } from "react";
+
+function CandidatesPageContent() {
+  const { showTaken, setShowTaken, fetchCandidateTaskApps, isLoading } =
+    useCandidateTask();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true);
+    await fetchCandidateTaskApps();
+    setIsRefreshing(false);
+  };
+
+  return (
+    <div className="flex w-dvw min-h-dvh justify-center items-start p-8 md:p-16">
+      <div className="flex flex-col gap-4 w-full">
+        <h1 className="text-2xl font-bold">Candidates</h1>
+        <div className="flex items-center gap-10">
+          <div className="flex items-center gap-2">
+            <Switch checked={showTaken} onCheckedChange={setShowTaken} />
+            <Label>Show Taken Apps</Label>
+          </div>
+          <Button
+            className="h-full"
+            onClick={handleRefresh}
+            disabled={isLoading || isRefreshing}
+          >
+            {isLoading || isRefreshing ? (
+              <>
+                <RefreshCcw className="w-4 h-4 animate-spin" />
+                Refreshing...
+              </>
+            ) : (
+              <>
+                Refresh Apps <RefreshCcw className="w-4 h-4" />
+              </>
+            )}
+          </Button>
+        </div>
+        <CandidateTaskSearch />
+        <CandidateTaskGallery />
+      </div>
+    </div>
+  );
+}
+
+export function CandidatesClient() {
+  return (
+    <CandidateTaskProvider>
+      <CandidatesPageContent />
+    </CandidateTaskProvider>
+  );
+}

--- a/src/app/(signed-in)/candidates/components/candidate-gallery.tsx
+++ b/src/app/(signed-in)/candidates/components/candidate-gallery.tsx
@@ -1,171 +1,453 @@
 import { Badge } from "@/components/ui/badge";
-import Image from "next/image";
-import { useState } from "react";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { Separator } from "@radix-ui/react-dropdown-menu";
-import { Check, Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useCandidateTask } from "@/app/(signed-in)/candidates/components/candidate-task-context";
 import { CandidateTaskApp } from "@/lib/actions";
+import { CandidateTask } from "@prisma/client";
+import {
+  Check,
+  ClipboardCopy,
+  Copy,
+  Eye,
+  EyeOff,
+  Sparkles,
+} from "lucide-react";
+import Image from "next/image";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+type CopiedState = "all" | number | null;
+
+const WithTooltip = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) => (
+  <Tooltip>
+    <TooltipTrigger asChild>{children}</TooltipTrigger>
+    <TooltipContent>{label}</TooltipContent>
+  </Tooltip>
+);
 
 export const CandidateTaskGallery = () => {
   const { candidateTaskApps, isLoading, hasMore, loadMore, isLoadingMore } =
     useCandidateTask();
   const [selectedAppId, setSelectedAppId] = useState<string | null>(null);
 
+  const selectedApp = useMemo(
+    () => candidateTaskApps.find((app) => app.id === selectedAppId) ?? null,
+    [candidateTaskApps, selectedAppId],
+  );
+
   if (isLoading) {
     return (
-      <div className="flex w-dvw min-h-dvh justify-center items-start p-8 md:p-16">
+      <div className="flex min-h-[40vh] w-full items-start justify-center p-8 md:p-16">
         <div className="text-muted-foreground">Loading apps...</div>
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-2 md:gap-4 p-4 lg:p-6">
-      {candidateTaskApps.length > 0 ? (
-        candidateTaskApps.map((candidateTaskApp) => (
-          <CandidateGalleryAppCard
-            key={candidateTaskApp.id}
-            candidateTaskApp={candidateTaskApp}
-            selectedAppId={selectedAppId}
-            setSelectedAppId={setSelectedAppId}
-          />
-        ))
-      ) : (
-        <CandidateGalleryNoApps />
-      )}
+    <TooltipProvider>
+      <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
+        {candidateTaskApps.length > 0 ? (
+          candidateTaskApps.map((candidateTaskApp) => (
+            <CandidateGalleryAppCard
+              key={candidateTaskApp.id}
+              candidateTaskApp={candidateTaskApp}
+              onSelect={() => setSelectedAppId(candidateTaskApp.id)}
+            />
+          ))
+        ) : (
+          <CandidateGalleryNoApps />
+        )}
+      </div>
       {hasMore && (
-        <div className="flex justify-center p-4">
+        <div className="flex justify-center px-4 pb-6">
           <Button onClick={loadMore} disabled={isLoadingMore} variant="outline">
             {isLoadingMore ? "Loading..." : "Load More"}
           </Button>
         </div>
       )}
-    </div>
+      <CandidateTaskDrawer
+        candidateTaskApp={selectedApp}
+        open={!!selectedApp}
+        onOpenChange={(open) => {
+          if (!open) setSelectedAppId(null);
+        }}
+      />
+    </TooltipProvider>
   );
 };
 
 const CandidateGalleryAppCard = ({
   candidateTaskApp,
-  selectedAppId,
-  setSelectedAppId,
+  onSelect,
 }: {
   candidateTaskApp: CandidateTaskApp;
-  selectedAppId: string | null;
-  setSelectedAppId: (appId: string | null) => void;
+  onSelect: () => void;
 }) => {
-  const [copyIcon, setCopyIcon] = useState<"copy" | "check">("copy");
-  const { handleSetAppTaken } = useCandidateTask();
-  const taskDescriptions = candidateTaskApp.tasks.map(
-    (task) => task.description
-  );
-
-  const handleCopy = (tasks: string[]) => {
-    navigator.clipboard.writeText(tasks.join("\n"));
-    setCopyIcon("check");
-    setTimeout(() => {
-      setCopyIcon("copy");
-    }, 2000);
-  };
-
-  const handleCopyIcon = () => {
-    return copyIcon === "copy" ? (
-      <Copy
-        className="w-4 h-4 text-muted-foreground cursor-pointer"
-        onClick={() => handleCopy(taskDescriptions)}
-      />
-    ) : (
-      <Check
-        className="w-4 h-4 text-muted-foreground cursor-pointer"
-        onClick={() => setCopyIcon("copy")}
-      />
-    );
-  };
+  const visibleTaskCount = candidateTaskApp.tasks.filter(
+    (task) => task.status !== "hidden",
+  ).length;
+  const hiddenTaskCount = candidateTaskApp.tasks.length - visibleTaskCount;
 
   return (
-    <Collapsible open={selectedAppId === candidateTaskApp.id}>
-      <div className="flex flex-col overflow-hidden p-3 items-center justify-center rounded-lg hover:shadow-md cursor-pointer">
-        <CollapsibleTrigger asChild>
-          <div className="relative inline-block mb-2">
-            <Image
-              src={candidateTaskApp.app.metadata.icon}
-              alt={`${candidateTaskApp.app.metadata.name} icon`}
-              width={48}
-              height={48}
-              sizes="100vw"
-              className="rounded-xl aspect-square drop-shadow-md object-cover"
-              onClick={() => {
-                if (selectedAppId === candidateTaskApp.id) {
-                  setSelectedAppId(null);
-                } else {
-                  setSelectedAppId(candidateTaskApp.id);
-                }
-              }}
-            />
-            <Badge
-              variant="destructive"
-              className="absolute -top-2 -right-2 h-5 w-5 rounded-full flex items-center justify-center text-xs p-0 font-bold shadow-lg z-10 bg-blue-500 text-white"
-            >
-              {candidateTaskApp.tasks.length}
-            </Badge>
-          </div>
-        </CollapsibleTrigger>
-        <div className="flex flex-col grow min-w-0 justify-center items-center">
-          <h2 className="text-sm font-medium leading-tight tracking-tight">
+    <WithTooltip label="Open task list">
+      <button
+        type="button"
+        onClick={onSelect}
+        className="flex min-h-36 cursor-pointer flex-col items-center justify-start gap-2 rounded-md border bg-background p-3 text-center transition hover:border-primary/50 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+      >
+        <div className="relative">
+          <Image
+            src={candidateTaskApp.app.metadata.icon}
+            alt={`${candidateTaskApp.app.metadata.name} icon`}
+            width={56}
+            height={56}
+            sizes="56px"
+            className="aspect-square rounded-xl object-cover drop-shadow-sm"
+          />
+          <Badge className="absolute -right-2 -top-2 flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-600 px-1 text-xs text-white">
+            {visibleTaskCount}
+          </Badge>
+        </div>
+        <div className="min-w-0 space-y-1">
+          <h2 className="min-h-10 max-w-full break-all text-sm font-medium leading-tight">
             {candidateTaskApp.app.metadata.name}
           </h2>
-          <div className="flex flex-wrap gap-1 mt-1">
+          <div className="flex flex-wrap justify-center gap-1">
             {candidateTaskApp.app.metadata.genre
               .slice(0, 2)
               .map((genre, index) => (
                 <Badge
-                  key={index}
+                  key={`${genre}-${index}`}
                   variant="outline"
-                  className="text-xs px-1 py-0 h-4"
+                  className="h-5 px-1 text-xs"
                 >
                   {genre}
                 </Badge>
               ))}
-            {candidateTaskApp.app.metadata.genre.length > 2 && (
-              <Badge variant="outline" className="text-xs px-1 py-0 h-4">
-                +{candidateTaskApp.app.metadata.genre.length - 2}
-              </Badge>
-            )}
           </div>
+          {hiddenTaskCount > 0 ? (
+            <div className="text-xs text-muted-foreground">
+              {hiddenTaskCount} hidden
+            </div>
+          ) : null}
         </div>
-        <Button
-          variant={candidateTaskApp.isTaken ? "destructive" : "default"}
-          size="sm"
-          onClick={() =>
-            handleSetAppTaken(candidateTaskApp.id, !candidateTaskApp.isTaken)
-          }
-          className="w-full text-xs"
-        >
-          {candidateTaskApp.isTaken ? "Mark as Available" : "Mark as Taken"}
-        </Button>
-        <Separator className="w-full" />
-        <CollapsibleContent className="w-full mt-1 p-2 border rounded-lg">
-          <div className="flex items-center justify-between">
-            <h2 className="text-sm font-medium leading-tight tracking-tight mb-1">
-              Candidate Tasks
-            </h2>
-            {handleCopyIcon()}
-          </div>
-          <ul className="list-disc list-inside">
-            {candidateTaskApp.tasks.map((task, index) => (
-              <li className="text-xs text-muted-foreground mb-1" key={index}>
-                {task.description}
-              </li>
-            ))}
-          </ul>
-        </CollapsibleContent>
+      </button>
+    </WithTooltip>
+  );
+};
+
+const CandidateTaskDrawer = ({
+  candidateTaskApp,
+  open,
+  onOpenChange,
+}: {
+  candidateTaskApp: CandidateTaskApp | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) => {
+  const { handleSetAppTaken, handleSetTaskStatus } = useCandidateTask();
+  const [copied, setCopied] = useState<CopiedState>(null);
+  const [showHidden, setShowHidden] = useState(false);
+  const [pendingTaskIndex, setPendingTaskIndex] = useState<number | null>(null);
+  const [isClaiming, setIsClaiming] = useState(false);
+
+  const hiddenCount =
+    candidateTaskApp?.tasks.filter((task) => task.status === "hidden").length ??
+    0;
+  const visibleTasks =
+    candidateTaskApp?.tasks
+      .map((task, index) => ({ task, index }))
+      .filter(({ task }) => showHidden || task.status !== "hidden") ?? [];
+  const visibleTaskDescriptions = candidateTaskApp
+    ? candidateTaskApp.tasks
+        .filter((task) => task.status !== "hidden")
+        .map((task) => task.description)
+    : [];
+
+  useEffect(() => {
+    setCopied(null);
+    setShowHidden(false);
+    setPendingTaskIndex(null);
+    setIsClaiming(false);
+  }, [candidateTaskApp?.id]);
+
+  const copyText = async (text: string, copiedState: CopiedState) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(copiedState);
+      setTimeout(() => setCopied(null), 1800);
+    } catch {
+      toast.error("Unable to copy task text.");
+    }
+  };
+
+  const handleTaskStatus = async (
+    taskIndex: number,
+    status: "open" | "hidden",
+  ) => {
+    if (!candidateTaskApp) return;
+    setPendingTaskIndex(taskIndex);
+    const ok = await handleSetTaskStatus(
+      candidateTaskApp.id,
+      taskIndex,
+      status,
+    );
+    setPendingTaskIndex(null);
+    if (ok && status === "open" && hiddenCount <= 1) {
+      setShowHidden(false);
+    }
+  };
+
+  const handleClaim = async () => {
+    if (!candidateTaskApp) return;
+    setIsClaiming(true);
+    await handleSetAppTaken(candidateTaskApp.id, !candidateTaskApp.isTaken);
+    setIsClaiming(false);
+    onOpenChange(false);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="flex w-full max-w-none flex-col p-0 sm:max-w-xl"
+      >
+        {candidateTaskApp ? (
+          <>
+            <SheetHeader className="border-b px-5 py-4 text-left">
+              <div className="flex items-start gap-3 pr-8">
+                <Image
+                  src={candidateTaskApp.app.metadata.icon}
+                  alt={`${candidateTaskApp.app.metadata.name} icon`}
+                  width={48}
+                  height={48}
+                  sizes="48px"
+                  className="aspect-square rounded-xl object-cover"
+                />
+                <div className="min-w-0 flex-1">
+                  <SheetTitle className="truncate">
+                    {candidateTaskApp.app.metadata.name}
+                  </SheetTitle>
+                  <SheetDescription>
+                    {visibleTaskDescriptions.length} available tasks
+                    {hiddenCount > 0 ? ` · ${hiddenCount} hidden` : ""}
+                  </SheetDescription>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2 pt-3">
+                <WithTooltip label="Copy all visible tasks">
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() =>
+                      copyText(visibleTaskDescriptions.join("\n"), "all")
+                    }
+                    disabled={visibleTaskDescriptions.length === 0}
+                    variant="outline"
+                  >
+                    {copied === "all" ? (
+                      <Check className="size-4" />
+                    ) : (
+                      <Copy className="size-4" />
+                    )}
+                    Copy all
+                  </Button>
+                </WithTooltip>
+                <WithTooltip
+                  label={
+                    candidateTaskApp.isTaken
+                      ? "Return this app to the available list"
+                      : "Reserve this app for yourself"
+                  }
+                >
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={handleClaim}
+                    disabled={isClaiming}
+                    variant={
+                      candidateTaskApp.isTaken ? "destructive" : "default"
+                    }
+                  >
+                    {isClaiming
+                      ? "Saving..."
+                      : candidateTaskApp.isTaken
+                        ? "Mark available"
+                        : "Claim app"}
+                  </Button>
+                </WithTooltip>
+              </div>
+            </SheetHeader>
+            <div className="border-b px-5 py-3">
+              <div className="flex flex-wrap gap-2 text-xs">
+                <SourceBadge generated={false} />
+                <SourceBadge generated />
+              </div>
+            </div>
+            {hiddenCount > 0 ? (
+              <div className="border-b px-5 py-3">
+                <WithTooltip
+                  label={showHidden ? "Hide hidden tasks" : "Show hidden tasks"}
+                >
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => setShowHidden((prev) => !prev)}
+                  >
+                    {showHidden ? (
+                      <EyeOff className="size-4" />
+                    ) : (
+                      <Eye className="size-4" />
+                    )}
+                    {showHidden
+                      ? "Hide hidden"
+                      : `Show hidden (${hiddenCount})`}
+                  </Button>
+                </WithTooltip>
+              </div>
+            ) : null}
+            <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+              {visibleTasks.length > 0 ? (
+                <div className="space-y-3">
+                  {visibleTasks.map(({ task, index }) => (
+                    <CandidateTaskRow
+                      key={`${candidateTaskApp.id}-${index}`}
+                      task={task}
+                      index={index}
+                      copied={copied}
+                      pending={pendingTaskIndex === index}
+                      onCopy={() => copyText(task.description, index)}
+                      onStatusChange={(status) =>
+                        handleTaskStatus(index, status)
+                      }
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+                  No visible tasks for this app.
+                </div>
+              )}
+            </div>
+          </>
+        ) : null}
+      </SheetContent>
+    </Sheet>
+  );
+};
+
+const CandidateTaskRow = ({
+  task,
+  index,
+  copied,
+  pending,
+  onCopy,
+  onStatusChange,
+}: {
+  task: CandidateTask;
+  index: number;
+  copied: CopiedState;
+  pending: boolean;
+  onCopy: () => void;
+  onStatusChange: (status: "open" | "hidden") => void;
+}) => {
+  const isHidden = task.status === "hidden";
+
+  return (
+    <div
+      className={`rounded-md border p-2.5 ${
+        isHidden ? "bg-muted/40 text-muted-foreground" : "bg-background"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <SourceBadge generated={task.generated} />
+          <p className="mt-1.5 text-sm leading-5">{task.description}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <WithTooltip label="Copy task">
+            <Button type="button" size="icon" variant="ghost" onClick={onCopy}>
+              {copied === index ? (
+                <Check className="size-4" />
+              ) : (
+                <ClipboardCopy className="size-4" />
+              )}
+              <span className="sr-only">Copy task</span>
+            </Button>
+          </WithTooltip>
+          {isHidden ? (
+            <WithTooltip label="Restore this task to the visible list">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={pending}
+                onClick={() => onStatusChange("open")}
+                className="h-8 px-2"
+              >
+                <Eye className="size-4" />
+                {pending ? "..." : "Restore"}
+              </Button>
+            </WithTooltip>
+          ) : (
+            <WithTooltip label="Hide this task if it does not work">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={pending}
+                onClick={() => onStatusChange("hidden")}
+                className="h-8 px-2"
+              >
+                <EyeOff className="size-4" />
+                {pending ? "..." : "Hide"}
+              </Button>
+            </WithTooltip>
+          )}
+        </div>
       </div>
-    </Collapsible>
+    </div>
+  );
+};
+
+const SourceBadge = ({ generated }: { generated: boolean }) => {
+  if (generated) {
+    return (
+      <WithTooltip label="Task suggested by AI from the app description. Hide it if it does not work.">
+        <Badge className="bg-amber-100 text-amber-900 hover:bg-amber-100 dark:bg-amber-950 dark:text-amber-200">
+          <Sparkles className="size-3" />
+          AI-generated task
+        </Badge>
+      </WithTooltip>
+    );
+  }
+
+  return (
+    <WithTooltip label="Task found in existing app data.">
+      <Badge className="bg-emerald-100 text-emerald-900 hover:bg-emerald-100 dark:bg-emerald-950 dark:text-emerald-200">
+        <Check className="size-3" />
+        App task
+      </Badge>
+    </WithTooltip>
   );
 };
 

--- a/src/app/(signed-in)/candidates/components/candidate-search.tsx
+++ b/src/app/(signed-in)/candidates/components/candidate-search.tsx
@@ -1,5 +1,5 @@
 import { Input, InputIcon, InputRoot } from "@/components/ui/input-icon";
-import { Filter, RefreshCcw, Search } from "lucide-react";
+import { Filter, Search, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
@@ -52,6 +52,7 @@ export const CandidateTaskSearch = () => {
     resetFilters,
     showTaken,
   } = useCandidateTask();
+  const [showFilters, setShowFilters] = useState(false);
 
   const [buttonClickStates, setButtonClickStates] = useState<{
     [genre: string]: ButtonClickState;
@@ -88,6 +89,8 @@ export const CandidateTaskSearch = () => {
     }
   };
 
+  const activeFilterCount = selectedGenres.length + excludeGenres.length;
+
   const handleAllButtonClick = () => {
     setButtonClickStates(
       Object.fromEntries(
@@ -116,41 +119,82 @@ export const CandidateTaskSearch = () => {
         <Badge variant="secondary" className="h-full px-3">
           {totalCount} Apps {showTaken ? "Taken" : "Left"}
         </Badge>
-      </div>
-      <div className="flex flex-wrap gap-2 items-center">
         <Button
-          variant="secondary"
+          type="button"
+          variant={showFilters ? "default" : "outline"}
           className="h-full"
-          onClick={handleAllButtonClick}
+          onClick={() => setShowFilters((prev) => !prev)}
         >
-          All
+          <Filter className="text-muted-foreground" />
+          Filters{activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
         </Button>
-        {iosAppGenres.map((genre) => (
-          <Button
-            key={genre}
-            variant="secondary"
-            className={`h-full ${
-              selectedGenres.includes(genre)
-                ? "bg-green-500/50 hover:bg-green-600/50 dark:bg-green-400/50 dark:hover:bg-green-500/50"
-                : ""
-            } ${
-              excludeGenres.includes(genre)
-                ? "bg-red-500/50 hover:bg-red-600/50 dark:bg-red-400/50 dark:hover:bg-red-500/50"
-                : ""
-            }`}
-            onClick={() => handleButtonClick(genre)}
-          >
-            <Filter
-              className={`text-muted-foreground ${
-                selectedGenres.includes(genre)
-                  ? "text-primary"
-                  : "text-muted-foreground"
-              }`}
-            />
-            {genre}
-          </Button>
-        ))}
       </div>
+      {activeFilterCount > 0 ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {selectedGenres.map((genre) => (
+            <Badge
+              key={`selected-${genre}`}
+              className="bg-green-100 text-green-900 hover:bg-green-100 dark:bg-green-950 dark:text-green-200"
+            >
+              Include {genre}
+            </Badge>
+          ))}
+          {excludeGenres.map((genre) => (
+            <Badge
+              key={`excluded-${genre}`}
+              className="bg-red-100 text-red-900 hover:bg-red-100 dark:bg-red-950 dark:text-red-200"
+            >
+              Exclude {genre}
+            </Badge>
+          ))}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2"
+            onClick={handleAllButtonClick}
+          >
+            <X className="size-4" />
+            Clear
+          </Button>
+        </div>
+      ) : null}
+      {showFilters ? (
+        <div className="rounded-md border bg-background p-3">
+          <div className="mb-2 text-xs text-muted-foreground">
+            Click once to include a genre, twice to exclude it.
+          </div>
+          <div className="flex flex-wrap gap-2 items-center">
+            {iosAppGenres.map((genre) => (
+              <Button
+                key={genre}
+                type="button"
+                variant="secondary"
+                size="sm"
+                className={`h-8 ${
+                  selectedGenres.includes(genre)
+                    ? "bg-green-500/50 hover:bg-green-600/50 dark:bg-green-400/50 dark:hover:bg-green-500/50"
+                    : ""
+                } ${
+                  excludeGenres.includes(genre)
+                    ? "bg-red-500/50 hover:bg-red-600/50 dark:bg-red-400/50 dark:hover:bg-red-500/50"
+                    : ""
+                }`}
+                onClick={() => handleButtonClick(genre)}
+              >
+                <Filter
+                  className={`text-muted-foreground ${
+                    selectedGenres.includes(genre)
+                      ? "text-primary"
+                      : "text-muted-foreground"
+                  }`}
+                />
+                {genre}
+              </Button>
+            ))}
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/app/(signed-in)/candidates/components/candidate-task-context.tsx
+++ b/src/app/(signed-in)/candidates/components/candidate-task-context.tsx
@@ -6,10 +6,12 @@ import {
   useState,
   useEffect,
   useCallback,
+  useRef,
   ReactNode,
 } from "react";
 import {
   CandidateTaskApp,
+  setCandidateTaskStatus,
   setCandidateTaskAppTakenStatus,
   getCandidateTaskApps,
 } from "@/lib/actions";
@@ -33,6 +35,11 @@ interface CandidateTaskContextType {
   setExcludeGenres: (genres: string[]) => void;
   setShowTaken: (show: boolean) => void;
   handleSetAppTaken: (id: string, isTaken: boolean) => Promise<void>;
+  handleSetTaskStatus: (
+    id: string,
+    taskIndex: number,
+    status: "open" | "hidden"
+  ) => Promise<boolean>;
   loadMore: () => void;
   resetFilters: () => void;
   fetchCandidateTaskApps: () => void;
@@ -54,7 +61,8 @@ export function CandidateTaskProvider({ children }: { children: ReactNode }) {
   const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
   const [excludeGenres, setExcludeGenres] = useState<string[]>([]);
   const [showTaken, setShowTaken] = useState(false);
-  const [page, setPage] = useState(1);
+  const [, setPage] = useState(1);
+  const pageRef = useRef(1);
 
   const debouncedSearch = useDebounce(search, 500);
   const pageSize = 100;
@@ -67,12 +75,14 @@ export function CandidateTaskProvider({ children }: { children: ReactNode }) {
           setIsLoadingMore(true);
         } else {
           setIsLoading(true);
+          pageRef.current = 1;
           setPage(1);
         }
 
+        const nextPage = isLoadMore ? pageRef.current + 1 : 1;
         const res = await getCandidateTaskApps({
           isTaken: showTaken,
-          page: isLoadMore ? page + 1 : 1,
+          page: nextPage,
           pageSize,
           search: debouncedSearch,
           selectedGenres,
@@ -85,9 +95,11 @@ export function CandidateTaskProvider({ children }: { children: ReactNode }) {
               ...prev,
               ...res.data!.candidateTaskApps,
             ]);
-            setPage((prev) => prev + 1);
+            pageRef.current = nextPage;
+            setPage(nextPage);
           } else {
             setCandidateTaskApps(res.data.candidateTaskApps);
+            pageRef.current = 1;
             setPage(1);
           }
           setTotalCount(res.data.totalCount);
@@ -100,7 +112,7 @@ export function CandidateTaskProvider({ children }: { children: ReactNode }) {
         setIsLoadingMore(false);
       }
     },
-    [showTaken, page, pageSize, debouncedSearch, selectedGenres, excludeGenres]
+    [showTaken, pageSize, debouncedSearch, selectedGenres, excludeGenres]
   );
 
   // Auto-fetch when filters change
@@ -118,6 +130,26 @@ export function CandidateTaskProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  const handleSetTaskStatus = async (
+    id: string,
+    taskIndex: number,
+    status: "open" | "hidden"
+  ) => {
+    const result = await setCandidateTaskStatus({ id, taskIndex, status });
+    if (!result.ok || !result.data) {
+      toast.error(result.message);
+      return false;
+    }
+
+    setCandidateTaskApps((prev) =>
+      prev.map((app) =>
+        app.id === id ? result.data!.candidateTaskApp : app
+      )
+    );
+    toast.success(status === "hidden" ? "Task hidden" : "Task restored");
+    return true;
+  };
+
   const loadMore = () => {
     if (hasMore && !isLoadingMore) {
       fetchCandidateTaskApps(true);
@@ -128,6 +160,7 @@ export function CandidateTaskProvider({ children }: { children: ReactNode }) {
     setSearch("");
     setSelectedGenres([]);
     setExcludeGenres([]);
+    pageRef.current = 1;
     setPage(1);
   };
 
@@ -148,6 +181,7 @@ export function CandidateTaskProvider({ children }: { children: ReactNode }) {
         setExcludeGenres,
         setShowTaken,
         handleSetAppTaken,
+        handleSetTaskStatus,
         loadMore,
         resetFilters,
         fetchCandidateTaskApps,

--- a/src/app/(signed-in)/candidates/page.tsx
+++ b/src/app/(signed-in)/candidates/page.tsx
@@ -1,65 +1,13 @@
-"use client";
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth/auth";
+import { CandidatesClient } from "./candidates-client";
 
-import { Switch } from "@/components/ui/switch";
-import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
-import { RefreshCcw } from "lucide-react";
-import { CandidateTaskGallery } from "./components/candidate-gallery";
-import { CandidateTaskSearch } from "./components/candidate-search";
-import {
-  CandidateTaskProvider,
-  useCandidateTask,
-} from "@/app/(signed-in)/candidates/components/candidate-task-context";
-import { useState } from "react";
+export default async function Page() {
+  const session = await auth();
 
-function CandidatesPage() {
-  const { showTaken, setShowTaken, fetchCandidateTaskApps, isLoading } =
-    useCandidateTask();
-  const [isRefreshing, setIsRefreshing] = useState(false);
+  if (!session?.user?.id) {
+    redirect("/sign-in?callbackUrl=/candidates");
+  }
 
-  const handleRefresh = async () => {
-    setIsRefreshing(true);
-    await fetchCandidateTaskApps();
-    setIsRefreshing(false);
-  };
-
-  return (
-    <div className="flex w-dvw min-h-dvh justify-center items-start p-8 md:p-16">
-      <div className="flex flex-col gap-4 w-full">
-        <h1 className="text-2xl font-bold">Candidates</h1>
-        <div className="flex items-center gap-10">
-          <div className="flex items-center gap-2">
-            <Switch checked={showTaken} onCheckedChange={setShowTaken} />
-            <Label>Show Taken Apps</Label>
-          </div>
-          <Button
-            className="h-full"
-            onClick={handleRefresh}
-            disabled={isLoading || isRefreshing}
-          >
-            {isLoading || isRefreshing ? (
-              <>
-                <RefreshCcw className="w-4 h-4 animate-spin" />
-                Refreshing...
-              </>
-            ) : (
-              <>
-                Refresh Apps <RefreshCcw className="w-4 h-4" />
-              </>
-            )}
-          </Button>
-        </div>
-        <CandidateTaskSearch />
-        <CandidateTaskGallery />
-      </div>
-    </div>
-  );
-}
-
-export default function Page() {
-  return (
-    <CandidateTaskProvider>
-      <CandidatesPage />
-    </CandidateTaskProvider>
-  );
+  return <CandidatesClient />;
 }

--- a/src/lib/actions/candidate-task-apps.ts
+++ b/src/lib/actions/candidate-task-apps.ts
@@ -27,6 +27,12 @@ const SetCandidateTaskAppTakenStatusInputSchema = z.object({
   isTaken: z.boolean(),
 });
 
+const SetCandidateTaskStatusInputSchema = z.object({
+  id: ObjectIdSchema,
+  taskIndex: z.number().int().nonnegative(),
+  status: z.enum(["open", "hidden"]),
+});
+
 /**
  * Fetches candidate task apps from the database.
  * @param isTaken Whether the candidate task app is taken.
@@ -165,6 +171,77 @@ export const setCandidateTaskAppTakenStatus = async ({
     return {
       ok: false,
       message: "Failed to set candidate task app taken status",
+      data: null,
+    };
+  }
+};
+
+export const setCandidateTaskStatus = async ({
+  id,
+  taskIndex,
+  status,
+}: {
+  id: string;
+  taskIndex: number;
+  status: "open" | "hidden";
+}): Promise<ActionPayload<{ candidateTaskApp: CandidateTaskApp }>> => {
+  const parsedInput = SetCandidateTaskStatusInputSchema.safeParse({
+    id,
+    taskIndex,
+    status,
+  });
+  if (!parsedInput.success) {
+    return {
+      ok: false,
+      message: "Invalid candidate task status input.",
+      data: null,
+    };
+  }
+
+  const input = parsedInput.data;
+
+  try {
+    const candidateTaskApp = await prisma.candidateTaskApp.findUnique({
+      where: { id: input.id },
+      include: { app: true },
+    });
+
+    if (!candidateTaskApp) {
+      return {
+        ok: false,
+        message: "Candidate task app not found.",
+        data: null,
+      };
+    }
+
+    if (input.taskIndex >= candidateTaskApp.tasks.length) {
+      return {
+        ok: false,
+        message: "Candidate task index is out of range.",
+        data: null,
+      };
+    }
+
+    const tasks = candidateTaskApp.tasks.map((task, index) =>
+      index === input.taskIndex ? { ...task, status: input.status } : task
+    );
+
+    const updated = await prisma.candidateTaskApp.update({
+      where: { id: input.id },
+      data: { tasks },
+      include: { app: true },
+    });
+
+    return {
+      ok: true,
+      message: "Candidate task status updated successfully",
+      data: { candidateTaskApp: updated },
+    };
+  } catch (error) {
+    console.error("Error setting candidate task status:", error);
+    return {
+      ok: false,
+      message: "Failed to set candidate task status",
       data: null,
     };
   }


### PR DESCRIPTION
Replace inline task expansion with an app-grid-to-drawer workflow. Add per-task
  source labels, copy controls, hide/restore status updates, compact filters,
  and auth protection for the candidates page.
