### PR TITLE
Add one-click candidate task capture flow

### DIFF
--- a/src/app/(signed-in)/candidates/components/candidate-gallery.tsx
+++ b/src/app/(signed-in)/candidates/components/candidate-gallery.tsx
@@ -22,9 +22,11 @@ import {
   Copy,
   Eye,
   EyeOff,
+  Play,
   Sparkles,
 } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -168,6 +170,9 @@ const CandidateTaskDrawer = ({
   const [showHidden, setShowHidden] = useState(false);
   const [pendingTaskIndex, setPendingTaskIndex] = useState<number | null>(null);
   const [isClaiming, setIsClaiming] = useState(false);
+  const [openedTaskIndexes, setOpenedTaskIndexes] = useState<Set<number>>(
+    () => new Set()
+  );
 
   const hiddenCount =
     candidateTaskApp?.tasks.filter((task) => task.status === "hidden").length ??
@@ -187,6 +192,7 @@ const CandidateTaskDrawer = ({
     setShowHidden(false);
     setPendingTaskIndex(null);
     setIsClaiming(false);
+    setOpenedTaskIndexes(new Set());
   }, [candidateTaskApp?.id]);
 
   const copyText = async (text: string, copiedState: CopiedState) => {
@@ -221,7 +227,6 @@ const CandidateTaskDrawer = ({
     setIsClaiming(true);
     await handleSetAppTaken(candidateTaskApp.id, !candidateTaskApp.isTaken);
     setIsClaiming(false);
-    onOpenChange(false);
   };
 
   return (
@@ -333,8 +338,17 @@ const CandidateTaskDrawer = ({
                       key={`${candidateTaskApp.id}-${index}`}
                       task={task}
                       index={index}
+                      candidateTaskAppId={candidateTaskApp.id}
+                      opened={openedTaskIndexes.has(index)}
                       copied={copied}
                       pending={pendingTaskIndex === index}
+                      onOpenCapture={() =>
+                        setOpenedTaskIndexes((prev) => {
+                          const next = new Set(prev);
+                          next.add(index);
+                          return next;
+                        })
+                      }
                       onCopy={() => copyText(task.description, index)}
                       onStatusChange={(status) =>
                         handleTaskStatus(index, status)
@@ -358,15 +372,21 @@ const CandidateTaskDrawer = ({
 const CandidateTaskRow = ({
   task,
   index,
+  candidateTaskAppId,
+  opened,
   copied,
   pending,
+  onOpenCapture,
   onCopy,
   onStatusChange,
 }: {
   task: CandidateTask;
   index: number;
+  candidateTaskAppId: string;
+  opened: boolean;
   copied: CopiedState;
   pending: boolean;
+  onOpenCapture: () => void;
   onCopy: () => void;
   onStatusChange: (status: "open" | "hidden") => void;
 }) => {
@@ -384,6 +404,37 @@ const CandidateTaskRow = ({
           <p className="mt-1.5 text-sm leading-5">{task.description}</p>
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          {!isHidden ? (
+            <WithTooltip
+              label={
+                opened
+                  ? "Capture form opened in a new tab"
+                  : "Create a capture with this app and task prefilled"
+              }
+            >
+              <Button
+                asChild
+                type="button"
+                size="sm"
+                variant={opened ? "outline" : "default"}
+                className="h-8 px-2"
+              >
+                <Link
+                  href={`/capture/new?candidateTaskAppId=${candidateTaskAppId}&taskIndex=${index}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={onOpenCapture}
+                >
+                  {opened ? (
+                    <Check className="size-4" />
+                  ) : (
+                    <Play className="size-4" />
+                  )}
+                  {opened ? "Opened" : "Start"}
+                </Link>
+              </Button>
+            </WithTooltip>
+          ) : null}
           <WithTooltip label="Copy task">
             <Button type="button" size="icon" variant="ghost" onClick={onCopy}>
               {copied === index ? (

--- a/src/app/(signed-in)/capture/new/capture-new-client.tsx
+++ b/src/app/(signed-in)/capture/new/capture-new-client.tsx
@@ -1,8 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
-import { createCaptureTask, revalidateCaptureCaches } from "@/lib/actions";
+import { SetStateAction, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  createCaptureTask,
+  getCandidateTaskCapturePrefill,
+  revalidateCaptureCaches,
+} from "@/lib/actions";
 import { Platform, prettyOS } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
@@ -15,8 +19,19 @@ import { Loader2 } from "lucide-react";
 import AddTaskInputs, { TaskCandidate } from "./components/add-task-inputs";
 import { Session } from "next-auth";
 
+type CandidateOrigin = {
+  candidateTaskAppId: string;
+  taskIndex: number;
+};
+
+const makeTaskCandidate = (description = ""): TaskCandidate => ({
+  id: `id_${Date.now()}_${Math.random().toString(16)}`,
+  description,
+});
+
 export default function CaptureNewClient({ user }: { user: Session["user"] }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const maxLength = 200;
 
@@ -25,14 +40,26 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
 
   // Multi-row description → later collapsed to a single string for capture
   const [tasks, setTasks] = useState<TaskCandidate[]>([
-    {
-      id: `id_${Date.now()}_${Math.random().toString(16)}`,
-      description: "",
-    },
+    makeTaskCandidate(),
   ]);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isPrefilling, setIsPrefilling] = useState(false);
   const [showAddApp, setShowAddApp] = useState(false);
+  const [candidateOrigin, setCandidateOrigin] = useState<CandidateOrigin | null>(
+    null
+  );
+
+  const handleManualSetApp = (
+    nextApp: SetStateAction<{ name: string; id: string }>
+  ) => {
+    setCandidateOrigin(null);
+    setApp(nextApp);
+  };
+
+  const handleManualSetTasks = (nextTasks: SetStateAction<TaskCandidate[]>) => {
+    setTasks(nextTasks);
+  };
 
   // Validation: all tasks must be non-empty (trimmed)
   const allFilled = tasks.every((t) => t.description.trim().length > 0);
@@ -59,6 +86,61 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
     setLastAddedId(null);
   }, [tasks, lastAddedId]);
 
+  useEffect(() => {
+    const candidateTaskAppId = searchParams.get("candidateTaskAppId");
+    const taskIndexParam = searchParams.get("taskIndex");
+    if (!candidateTaskAppId || taskIndexParam === null) {
+      return;
+    }
+
+    const taskIndex = Number(taskIndexParam);
+    if (!Number.isInteger(taskIndex) || taskIndex < 0) {
+      toast.error("Invalid candidate task link.");
+      return;
+    }
+
+    let ignore = false;
+    setIsPrefilling(true);
+
+    getCandidateTaskCapturePrefill({ candidateTaskAppId, taskIndex })
+      .then((result) => {
+        if (ignore) return;
+        if (!result.ok || !result.data) {
+          toast.error(result.message || "Unable to load candidate task.");
+          setCandidateOrigin(null);
+          return;
+        }
+
+        const prefillPlatform = result.data.platform as Platform;
+        if (!Object.values(Platform).includes(prefillPlatform)) {
+          toast.error("Candidate task has an unsupported platform.");
+          setCandidateOrigin(null);
+          return;
+        }
+
+        setPlatform(prefillPlatform);
+        setApp(result.data.app);
+        setTasks([makeTaskCandidate(result.data.task.description)]);
+        setCandidateOrigin({
+          candidateTaskAppId: result.data.candidateTaskAppId,
+          taskIndex: result.data.taskIndex,
+        });
+      })
+      .catch((error) => {
+        if (ignore) return;
+        console.error(error);
+        toast.error("Unable to load candidate task.");
+        setCandidateOrigin(null);
+      })
+      .finally(() => {
+        if (!ignore) setIsPrefilling(false);
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [searchParams]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!user.id) {
@@ -71,25 +153,27 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
     }
     setIsSubmitting(true);
     try {
-      for (const task of tasks) {
+      for (const [index, task] of tasks.entries()) {
         const result = await createCaptureTask({
           appId: app.id,
           os: platform,
           description: task.description,
+          candidateOrigin:
+            index === 0 ? (candidateOrigin ?? undefined) : undefined,
         });
 
         if (!result.ok) {
           throw new Error(`Failed to create capture task: ${result.message}`);
         }
       }
+      toast.success("Capture tasks created! Redirecting...");
+      await revalidateCaptureCaches();
+      router.push(`/dashboard`);
     } catch (err) {
       toast.error(`Failed to create capture task.`);
       console.error(err);
     } finally {
-      toast.success("Capture tasks created! Redirecting...");
       setIsSubmitting(false);
-      await revalidateCaptureCaches();
-      router.push(`/dashboard`);
     }
   };
 
@@ -138,8 +222,10 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
                 setPlatform(selectPlatform as Platform);
                 // reset selected app on platform change
                 setApp({ name: "", id: "" });
+                setCandidateOrigin(null);
               }
             }}
+            disabled={isPrefilling || isSubmitting}
             className="w-full"
           >
             <ToggleGroupItem
@@ -163,12 +249,22 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
             2. Select App
           </Label>
           {app.name && <Badge>{app.name}</Badge>}
-          <AppGallery platform={platform} app={app} setApp={setApp} />
+          {isPrefilling ? (
+            <div className="flex items-center gap-2 rounded-md border border-dashed p-3 text-sm text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Loading candidate task...
+            </div>
+          ) : null}
+          <AppGallery
+            platform={platform}
+            app={app}
+            setApp={handleManualSetApp}
+          />
           <AddAppForm
             platform={platform}
             showAddApp={showAddApp}
             setShowAddApp={setShowAddApp}
-            setApp={setApp}
+            setApp={handleManualSetApp}
           />
         </div>
 
@@ -179,7 +275,7 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
           </Label>
 
           <AddTaskInputs
-            setTasks={setTasks}
+            setTasks={handleManualSetTasks}
             tasks={tasks}
             maxLength={maxLength}
             setLastAddedId={setLastAddedId}
@@ -190,10 +286,12 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
         <Button
           className="dark:bg-neutral-50 dark:text-black"
           type="submit"
-          disabled={!app.id || !allFilled || isSubmitting}
-          aria-disabled={!app.id || !allFilled || isSubmitting}
+          disabled={!app.id || !allFilled || isPrefilling || isSubmitting}
+          aria-disabled={!app.id || !allFilled || isPrefilling || isSubmitting}
         >
-          {isSubmitting && <Loader2 className="size-4 animate-spin" />}
+          {(isPrefilling || isSubmitting) && (
+            <Loader2 className="size-4 animate-spin" />
+          )}
           Start Capture
         </Button>
       </form>

--- a/src/app/(signed-in)/capture/new/page.tsx
+++ b/src/app/(signed-in)/capture/new/page.tsx
@@ -2,11 +2,25 @@ import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth/auth";
 import CaptureNewClient from "./capture-new-client";
 
-export default async function Page() {
+type PageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function Page({ searchParams }: PageProps) {
   const session = await auth();
+  const resolvedSearchParams = await searchParams;
 
   if (!session?.user?.id) {
-    redirect("/sign-in?callbackUrl=/capture/new");
+    const callbackParams = new URLSearchParams();
+    for (const [key, value] of Object.entries(resolvedSearchParams ?? {})) {
+      if (typeof value === "string") {
+        callbackParams.set(key, value);
+      }
+    }
+    const callbackUrl = `/capture/new${
+      callbackParams.size > 0 ? `?${callbackParams.toString()}` : ""
+    }`;
+    redirect(`/sign-in?callbackUrl=${encodeURIComponent(callbackUrl)}`);
   }
 
   return <CaptureNewClient user={session.user} />;

--- a/src/lib/actions/candidate-task-apps.ts
+++ b/src/lib/actions/candidate-task-apps.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@prisma/client";
 import { prisma } from "../prisma";
 import { ActionPayload } from "./types";
 import { z } from "zod";
+import { requireAuth } from "../auth/auth";
 
 export type CandidateTaskApp = Prisma.CandidateTaskAppGetPayload<{
   include: {
@@ -27,11 +28,32 @@ const SetCandidateTaskAppTakenStatusInputSchema = z.object({
   isTaken: z.boolean(),
 });
 
+const CandidateTaskStatusSchema = z.enum(["open", "started", "hidden"]);
+
 const SetCandidateTaskStatusInputSchema = z.object({
   id: ObjectIdSchema,
   taskIndex: z.number().int().nonnegative(),
-  status: z.enum(["open", "hidden"]),
+  status: CandidateTaskStatusSchema,
 });
+
+const GetCandidateTaskCapturePrefillInputSchema = z.object({
+  candidateTaskAppId: ObjectIdSchema,
+  taskIndex: z.number().int().nonnegative(),
+});
+
+export type CandidateTaskCapturePrefill = {
+  candidateTaskAppId: string;
+  taskIndex: number;
+  platform: string;
+  app: {
+    name: string;
+    id: string;
+  };
+  task: {
+    description: string;
+    status: string;
+  };
+};
 
 /**
  * Fetches candidate task apps from the database.
@@ -183,7 +205,7 @@ export const setCandidateTaskStatus = async ({
 }: {
   id: string;
   taskIndex: number;
-  status: "open" | "hidden";
+  status: z.infer<typeof CandidateTaskStatusSchema>;
 }): Promise<ActionPayload<{ candidateTaskApp: CandidateTaskApp }>> => {
   const parsedInput = SetCandidateTaskStatusInputSchema.safeParse({
     id,
@@ -222,15 +244,33 @@ export const setCandidateTaskStatus = async ({
       };
     }
 
-    const tasks = candidateTaskApp.tasks.map((task, index) =>
-      index === input.taskIndex ? { ...task, status: input.status } : task
-    );
+    await prisma.$runCommandRaw({
+      update: "candidate_task_apps",
+      updates: [
+        {
+          q: { _id: { $oid: input.id } },
+          u: {
+            $set: {
+              [`tasks.${input.taskIndex}.status`]: input.status,
+            },
+          },
+          multi: false,
+        },
+      ],
+    });
 
-    const updated = await prisma.candidateTaskApp.update({
+    const updated = await prisma.candidateTaskApp.findUnique({
       where: { id: input.id },
-      data: { tasks },
       include: { app: true },
     });
+
+    if (!updated) {
+      return {
+        ok: false,
+        message: "Candidate task app not found.",
+        data: null,
+      };
+    }
 
     return {
       ok: true,
@@ -242,6 +282,90 @@ export const setCandidateTaskStatus = async ({
     return {
       ok: false,
       message: "Failed to set candidate task status",
+      data: null,
+    };
+  }
+};
+
+export const getCandidateTaskCapturePrefill = async ({
+  candidateTaskAppId,
+  taskIndex,
+}: {
+  candidateTaskAppId: string;
+  taskIndex: number;
+}): Promise<ActionPayload<CandidateTaskCapturePrefill>> => {
+  const session = await requireAuth();
+  if (!session?.user?.id) {
+    return { ok: false, message: "User not authenticated.", data: null };
+  }
+
+  const parsedInput = GetCandidateTaskCapturePrefillInputSchema.safeParse({
+    candidateTaskAppId,
+    taskIndex,
+  });
+  if (!parsedInput.success) {
+    return {
+      ok: false,
+      message: "Invalid candidate task prefill input.",
+      data: null,
+    };
+  }
+
+  const input = parsedInput.data;
+
+  try {
+    const candidateTaskApp = await prisma.candidateTaskApp.findUnique({
+      where: { id: input.candidateTaskAppId },
+      include: { app: true },
+    });
+
+    if (!candidateTaskApp) {
+      return {
+        ok: false,
+        message: "Candidate task app not found.",
+        data: null,
+      };
+    }
+
+    const task = candidateTaskApp.tasks[input.taskIndex];
+    if (!task) {
+      return {
+        ok: false,
+        message: "Candidate task index is out of range.",
+        data: null,
+      };
+    }
+
+    if (task.status === "hidden") {
+      return {
+        ok: false,
+        message: "This candidate task is hidden and cannot be started.",
+        data: null,
+      };
+    }
+
+    return {
+      ok: true,
+      message: "Candidate task prefill found.",
+      data: {
+        candidateTaskAppId: candidateTaskApp.id,
+        taskIndex: input.taskIndex,
+        platform: candidateTaskApp.app.os,
+        app: {
+          name: candidateTaskApp.app.metadata.name,
+          id: candidateTaskApp.app.packageName,
+        },
+        task: {
+          description: task.description,
+          status: task.status,
+        },
+      },
+    };
+  } catch (error) {
+    console.error("Error fetching candidate task capture prefill:", error);
+    return {
+      ok: false,
+      message: "Failed to fetch candidate task prefill.",
       data: null,
     };
   }

--- a/src/lib/actions/capture.ts
+++ b/src/lib/actions/capture.ts
@@ -3,6 +3,7 @@
 import { unstable_cache, revalidateTag } from "next/cache";
 import { CaptureStatus, Prisma, ScreenGesture } from "@prisma/client";
 import { isValidObjectId } from "mongoose";
+import { z } from "zod";
 import { prisma } from "@/lib/prisma";
 import { listFromS3 } from "../aws";
 import { ActionPayload } from "./types";
@@ -384,6 +385,20 @@ export async function createCapture({
   }
 }
 
+const ObjectIdSchema = z.string().regex(/^[a-f0-9]{24}$/i);
+
+const CreateCaptureTaskInputSchema = z.object({
+  appId: z.string().min(1),
+  os: z.string().min(1),
+  description: z.string().trim().min(1).max(200),
+  candidateOrigin: z
+    .object({
+      candidateTaskAppId: ObjectIdSchema,
+      taskIndex: z.number().int().nonnegative(),
+    })
+    .optional(),
+});
+
 /**
  * Creates a new capture task in the database.
  * @param appId Id of the app to create the capture task for.
@@ -395,11 +410,32 @@ export async function createCaptureTask({
   appId,
   os,
   description,
+  candidateOrigin,
 }: {
   appId: string;
   os: string;
   description: string;
+  candidateOrigin?: {
+    candidateTaskAppId: string;
+    taskIndex: number;
+  };
 }) {
+  const parsedInput = CreateCaptureTaskInputSchema.safeParse({
+    appId,
+    os,
+    description,
+    candidateOrigin,
+  });
+  if (!parsedInput.success) {
+    return {
+      ok: false,
+      message: "Invalid capture task input.",
+      data: null,
+    };
+  }
+
+  const input = parsedInput.data;
+
   try {
     const session = await requireAuth();
 
@@ -408,17 +444,77 @@ export async function createCaptureTask({
     }
 
     const app = await prisma.app.findFirst({
-      where: { packageName: appId },
+      where: { packageName: input.appId, os: input.os },
     });
 
+    if (!app) {
+      return {
+        ok: false,
+        message: "Selected app not found.",
+        data: null,
+      };
+    }
+
+    let candidateTaskApp:
+      | Prisma.CandidateTaskAppGetPayload<{ include: { app: true } }>
+      | null = null;
+    if (input.candidateOrigin) {
+      candidateTaskApp = await prisma.candidateTaskApp.findUnique({
+        where: { id: input.candidateOrigin.candidateTaskAppId },
+        include: { app: true },
+      });
+
+      if (!candidateTaskApp) {
+        return {
+          ok: false,
+          message: "Candidate task app not found.",
+          data: null,
+        };
+      }
+
+      if (
+        candidateTaskApp.app.packageName !== input.appId ||
+        candidateTaskApp.app.os !== input.os ||
+        candidateTaskApp.appId !== app.id
+      ) {
+        return {
+          ok: false,
+          message: "Candidate task no longer matches the selected app.",
+          data: null,
+        };
+      }
+
+      const candidateTask =
+        candidateTaskApp.tasks[input.candidateOrigin.taskIndex];
+      if (!candidateTask) {
+        return {
+          ok: false,
+          message: "Candidate task index is out of range.",
+          data: null,
+        };
+      }
+
+      if (candidateTask.status === "hidden") {
+        return {
+          ok: false,
+          message: "This candidate task is hidden and cannot be started.",
+          data: null,
+        };
+      }
+    }
+
     const task = await prisma.task.create({
-      data: { appId, os, description },
+      data: {
+        appId: input.appId,
+        os: input.os,
+        description: input.description,
+      },
     });
 
     const capture = await prisma.capture.create({
       data: {
         app: {
-          connect: { id: app?.id },
+          connect: { id: app.id },
         },
         task: {
           connect: { id: task.id },
@@ -442,6 +538,25 @@ export async function createCaptureTask({
       return { ok: false, message: "Failed to update user.", data: null };
     }
 
+    if (input.candidateOrigin && candidateTaskApp) {
+      await prisma.$runCommandRaw({
+        update: "candidate_task_apps",
+        updates: [
+          {
+            q: { _id: { $oid: input.candidateOrigin.candidateTaskAppId } },
+            u: {
+              $set: {
+                isTaken: true,
+                [`tasks.${input.candidateOrigin.taskIndex}.status`]:
+                  "started",
+              },
+            },
+            multi: false,
+          },
+        ],
+      });
+    }
+
     return {
       ok: true,
       message: "Capture and task created.",
@@ -449,7 +564,11 @@ export async function createCaptureTask({
     };
   } catch (error) {
     console.error("Error creating capture/task:", error);
-    throw new Error("Failed to create capture and task");
+    return {
+      ok: false,
+      message: "Failed to create capture and task.",
+      data: null,
+    };
   }
 }
 


### PR DESCRIPTION
- add Start actions to candidate task rows that open prefilled /capture/new
  links
- fetch candidate prefill server-side from candidateTaskAppId and taskIndex
- validate candidate origin during capture creation before claiming progress
- mark candidate apps taken and candidate tasks started after capture creation
- preserve candidate deep links through auth redirects
- keep candidate drawer open after claim toggles
- add local Opened feedback for capture links
