### PR TITLE
Polish candidate capture creation flow

### DIFF
--- a/src/app/(signed-in)/candidates/components/candidate-gallery.tsx
+++ b/src/app/(signed-in)/candidates/components/candidate-gallery.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Sheet,
   SheetContent,
@@ -22,6 +23,7 @@ import {
   Copy,
   Eye,
   EyeOff,
+  ListChecks,
   Play,
   Sparkles,
 } from "lucide-react";
@@ -171,7 +173,10 @@ const CandidateTaskDrawer = ({
   const [pendingTaskIndex, setPendingTaskIndex] = useState<number | null>(null);
   const [isClaiming, setIsClaiming] = useState(false);
   const [openedTaskIndexes, setOpenedTaskIndexes] = useState<Set<number>>(
-    () => new Set()
+    () => new Set(),
+  );
+  const [selectedTaskIndexes, setSelectedTaskIndexes] = useState<Set<number>>(
+    () => new Set(),
   );
 
   const hiddenCount =
@@ -186,6 +191,15 @@ const CandidateTaskDrawer = ({
         .filter((task) => task.status !== "hidden")
         .map((task) => task.description)
     : [];
+  const selectedTaskIndexesList = Array.from(selectedTaskIndexes).sort(
+    (a, b) => a - b,
+  );
+  const selectedCaptureHref =
+    candidateTaskApp && selectedTaskIndexesList.length > 0
+      ? `/capture/new?candidateTaskAppId=${candidateTaskApp.id}&${selectedTaskIndexesList
+          .map((taskIndex) => `taskIndex=${taskIndex}`)
+          .join("&")}`
+      : "/capture/new";
 
   useEffect(() => {
     setCopied(null);
@@ -193,6 +207,7 @@ const CandidateTaskDrawer = ({
     setPendingTaskIndex(null);
     setIsClaiming(false);
     setOpenedTaskIndexes(new Set());
+    setSelectedTaskIndexes(new Set());
   }, [candidateTaskApp?.id]);
 
   const copyText = async (text: string, copiedState: CopiedState) => {
@@ -217,6 +232,13 @@ const CandidateTaskDrawer = ({
       status,
     );
     setPendingTaskIndex(null);
+    if (ok && status === "hidden") {
+      setSelectedTaskIndexes((prev) => {
+        const next = new Set(prev);
+        next.delete(taskIndex);
+        return next;
+      });
+    }
     if (ok && status === "open" && hiddenCount <= 1) {
       setShowHidden(false);
     }
@@ -276,6 +298,29 @@ const CandidateTaskDrawer = ({
                     Copy all
                   </Button>
                 </WithTooltip>
+                {selectedTaskIndexesList.length > 0 ? (
+                  <WithTooltip label="Create captures for selected tasks in a new tab">
+                    <Button asChild type="button" size="sm">
+                      <Link
+                        href={selectedCaptureHref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() =>
+                          setOpenedTaskIndexes((prev) => {
+                            const next = new Set(prev);
+                            selectedTaskIndexesList.forEach((taskIndex) =>
+                              next.add(taskIndex),
+                            );
+                            return next;
+                          })
+                        }
+                      >
+                        <ListChecks className="size-4" />
+                        Start selected ({selectedTaskIndexesList.length})
+                      </Link>
+                    </Button>
+                  </WithTooltip>
+                ) : null}
                 <WithTooltip
                   label={
                     candidateTaskApp.isTaken
@@ -340,8 +385,20 @@ const CandidateTaskDrawer = ({
                       index={index}
                       candidateTaskAppId={candidateTaskApp.id}
                       opened={openedTaskIndexes.has(index)}
+                      selected={selectedTaskIndexes.has(index)}
                       copied={copied}
                       pending={pendingTaskIndex === index}
+                      onSelectedChange={(checked) =>
+                        setSelectedTaskIndexes((prev) => {
+                          const next = new Set(prev);
+                          if (checked) {
+                            next.add(index);
+                          } else {
+                            next.delete(index);
+                          }
+                          return next;
+                        })
+                      }
                       onOpenCapture={() =>
                         setOpenedTaskIndexes((prev) => {
                           const next = new Set(prev);
@@ -374,8 +431,10 @@ const CandidateTaskRow = ({
   index,
   candidateTaskAppId,
   opened,
+  selected,
   copied,
   pending,
+  onSelectedChange,
   onOpenCapture,
   onCopy,
   onStatusChange,
@@ -384,8 +443,10 @@ const CandidateTaskRow = ({
   index: number;
   candidateTaskAppId: string;
   opened: boolean;
+  selected: boolean;
   copied: CopiedState;
   pending: boolean;
+  onSelectedChange: (checked: boolean) => void;
   onOpenCapture: () => void;
   onCopy: () => void;
   onStatusChange: (status: "open" | "hidden") => void;
@@ -399,6 +460,14 @@ const CandidateTaskRow = ({
       }`}
     >
       <div className="flex items-start justify-between gap-2">
+        {!isHidden ? (
+          <Checkbox
+            checked={selected}
+            onCheckedChange={(checked) => onSelectedChange(checked === true)}
+            aria-label="Select task"
+            className="mt-1 cursor-pointer"
+          />
+        ) : null}
         <div className="min-w-0 flex-1">
           <SourceBadge generated={task.generated} />
           <p className="mt-1.5 text-sm leading-5">{task.description}</p>
@@ -484,7 +553,7 @@ const SourceBadge = ({ generated }: { generated: boolean }) => {
   if (generated) {
     return (
       <WithTooltip label="Task suggested by AI from the app description. Hide it if it does not work.">
-        <Badge className="bg-amber-100 text-amber-900 hover:bg-amber-100 dark:bg-amber-950 dark:text-amber-200">
+        <Badge className="bg-amber-100 text-amber-900 hover:bg-amber-200 hover:text-amber-900 dark:bg-amber-950 dark:text-amber-200 dark:hover:bg-amber-900 dark:hover:text-amber-200">
           <Sparkles className="size-3" />
           AI-generated task
         </Badge>
@@ -494,7 +563,7 @@ const SourceBadge = ({ generated }: { generated: boolean }) => {
 
   return (
     <WithTooltip label="Task found in existing app data.">
-      <Badge className="bg-emerald-100 text-emerald-900 hover:bg-emerald-100 dark:bg-emerald-950 dark:text-emerald-200">
+      <Badge className="bg-emerald-100 text-emerald-900 hover:bg-emerald-200 hover:text-emerald-900 dark:bg-emerald-950 dark:text-emerald-200 dark:hover:bg-emerald-900 dark:hover:text-emerald-200">
         <Check className="size-3" />
         App task
       </Badge>

--- a/src/app/(signed-in)/capture/new/capture-new-client.tsx
+++ b/src/app/(signed-in)/capture/new/capture-new-client.tsx
@@ -24,9 +24,13 @@ type CandidateOrigin = {
   taskIndex: number;
 };
 
-const makeTaskCandidate = (description = ""): TaskCandidate => ({
+const makeTaskCandidate = (
+  description = "",
+  candidateOrigin?: CandidateOrigin,
+): TaskCandidate => ({
   id: `id_${Date.now()}_${Math.random().toString(16)}`,
   description,
+  candidateOrigin,
 });
 
 export default function CaptureNewClient({ user }: { user: Session["user"] }) {
@@ -39,22 +43,20 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
   const [app, setApp] = useState({ name: "", id: "" });
 
   // Multi-row description → later collapsed to a single string for capture
-  const [tasks, setTasks] = useState<TaskCandidate[]>([
-    makeTaskCandidate(),
-  ]);
+  const [tasks, setTasks] = useState<TaskCandidate[]>([makeTaskCandidate()]);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isPrefilling, setIsPrefilling] = useState(false);
   const [showAddApp, setShowAddApp] = useState(false);
-  const [candidateOrigin, setCandidateOrigin] = useState<CandidateOrigin | null>(
-    null
-  );
 
   const handleManualSetApp = (
-    nextApp: SetStateAction<{ name: string; id: string }>
+    nextApp: SetStateAction<{ name: string; id: string }>,
   ) => {
-    setCandidateOrigin(null);
     setApp(nextApp);
+    setTasks((prev) =>
+      // clear candidate origin when app is set manually
+      prev.map(({ candidateOrigin: _candidateOrigin, ...task }) => task),
+    );
   };
 
   const handleManualSetTasks = (nextTasks: SetStateAction<TaskCandidate[]>) => {
@@ -88,13 +90,19 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
 
   useEffect(() => {
     const candidateTaskAppId = searchParams.get("candidateTaskAppId");
-    const taskIndexParam = searchParams.get("taskIndex");
-    if (!candidateTaskAppId || taskIndexParam === null) {
+    const taskIndexParams = searchParams.getAll("taskIndex");
+    if (!candidateTaskAppId || taskIndexParams.length === 0) {
       return;
     }
 
-    const taskIndex = Number(taskIndexParam);
-    if (!Number.isInteger(taskIndex) || taskIndex < 0) {
+    const taskIndexes = Array.from(
+      new Set(taskIndexParams.map((taskIndexParam) => Number(taskIndexParam))),
+    );
+    if (
+      taskIndexes.some(
+        (taskIndex) => !Number.isInteger(taskIndex) || taskIndex < 0,
+      )
+    ) {
       toast.error("Invalid candidate task link.");
       return;
     }
@@ -102,35 +110,32 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
     let ignore = false;
     setIsPrefilling(true);
 
-    getCandidateTaskCapturePrefill({ candidateTaskAppId, taskIndex })
+    getCandidateTaskCapturePrefill({ candidateTaskAppId, taskIndexes })
       .then((result) => {
         if (ignore) return;
         if (!result.ok || !result.data) {
           toast.error(result.message || "Unable to load candidate task.");
-          setCandidateOrigin(null);
           return;
         }
 
         const prefillPlatform = result.data.platform as Platform;
         if (!Object.values(Platform).includes(prefillPlatform)) {
           toast.error("Candidate task has an unsupported platform.");
-          setCandidateOrigin(null);
           return;
         }
 
         setPlatform(prefillPlatform);
         setApp(result.data.app);
-        setTasks([makeTaskCandidate(result.data.task.description)]);
-        setCandidateOrigin({
-          candidateTaskAppId: result.data.candidateTaskAppId,
-          taskIndex: result.data.taskIndex,
-        });
+        setTasks(
+          result.data.tasks.map((task) =>
+            makeTaskCandidate(task.description, task.origin),
+          ),
+        );
       })
       .catch((error) => {
         if (ignore) return;
         console.error(error);
         toast.error("Unable to load candidate task.");
-        setCandidateOrigin(null);
       })
       .finally(() => {
         if (!ignore) setIsPrefilling(false);
@@ -153,13 +158,12 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
     }
     setIsSubmitting(true);
     try {
-      for (const [index, task] of tasks.entries()) {
+      for (const task of tasks) {
         const result = await createCaptureTask({
           appId: app.id,
           os: platform,
           description: task.description,
-          candidateOrigin:
-            index === 0 ? (candidateOrigin ?? undefined) : undefined,
+          candidateOrigin: task.candidateOrigin,
         });
 
         if (!result.ok) {
@@ -222,7 +226,11 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
                 setPlatform(selectPlatform as Platform);
                 // reset selected app on platform change
                 setApp({ name: "", id: "" });
-                setCandidateOrigin(null);
+                setTasks((prev) =>
+                  prev.map(
+                    ({ candidateOrigin: _candidateOrigin, ...task }) => task,
+                  ),
+                );
               }
             }}
             disabled={isPrefilling || isSubmitting}
@@ -245,10 +253,26 @@ export default function CaptureNewClient({ user }: { user: Session["user"] }) {
 
         {/* App */}
         <div className="space-y-2 dark:text-white">
-          <Label htmlFor="app" className="mr-5 font-bold">
-            2. Select App
-          </Label>
-          {app.name && <Badge>{app.name}</Badge>}
+          <div className="flex flex-wrap items-start justify-between gap-2">
+            <Label htmlFor="app" className="font-bold">
+              2. Select App
+            </Label>
+            {app.name ? (
+              <div className="flex max-w-full items-center gap-2 rounded-md border border-primary/40 bg-primary/5 px-2 py-1 sm:max-w-[65%]">
+                <div className="min-w-0">
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Selected
+                  </div>
+                  <div className="truncate text-sm font-semibold">
+                    {app.name}
+                  </div>
+                </div>
+                <Badge variant="outline" className="shrink-0">
+                  {prettyOS(platform)}
+                </Badge>
+              </div>
+            ) : null}
+          </div>
           {isPrefilling ? (
             <div className="flex items-center gap-2 rounded-md border border-dashed p-3 text-sm text-muted-foreground">
               <Loader2 className="size-4 animate-spin" />

--- a/src/app/(signed-in)/capture/new/components/add-app-form.tsx
+++ b/src/app/(signed-in)/capture/new/components/add-app-form.tsx
@@ -5,6 +5,7 @@ import { Dispatch, SetStateAction, useState } from "react";
 import {
   AppInput,
   checkIfAppExists,
+  checkIfIosAppExistsByStoreId,
   getAndroidApp,
   getIosApp,
   saveApp,
@@ -23,6 +24,25 @@ export default function AddAppForm({
   setApp: Dispatch<SetStateAction<{ name: string; id: string }>>;
 }) {
   const [newAppId, setNewAppId] = useState("");
+  const [isAddingApp, setIsAddingApp] = useState(false);
+
+  function parseStoreAppInput(input: string) {
+    const trimmedInput = input.trim();
+    try {
+      const url = new URL(trimmedInput);
+      if (platform === Platform.ANDROID) {
+        return url.searchParams.get("id")?.trim() || trimmedInput;
+      }
+
+      const appStoreId = url.pathname.match(/\/id(\d+)/)?.[1];
+      return appStoreId || trimmedInput;
+    } catch {
+      if (platform === Platform.IOS) {
+        return trimmedInput.match(/id(\d+)/)?.[1] || trimmedInput;
+      }
+      return trimmedInput;
+    }
+  }
 
   function convertToPrismaApp(data: any): AppInput {
     const app = {
@@ -58,60 +78,82 @@ export default function AddAppForm({
   }
 
   async function handleAddApp() {
-    if (!newAppId) return;
-    // FIXME: db check breaks for ios because we lookup id instead of appId
-    if (platform === Platform.ANDROID) {
-      const existing = await checkIfAppExists(newAppId, platform);
-      if (existing) {
-        toast.success("App already exists!");
-        setApp({
-          id: existing.packageName,
-          name: existing.metadata.name,
-        });
-        setShowAddApp(false);
+    const parsedAppId = parseStoreAppInput(newAppId);
+    if (!parsedAppId || isAddingApp) return;
+    setIsAddingApp(true);
+
+    try {
+      if (platform === Platform.ANDROID) {
+        const existing = await checkIfAppExists(parsedAppId, platform);
+        if (existing) {
+          toast.success("App already exists!");
+          setApp({
+            id: existing.packageName,
+            name: existing.metadata.name,
+          });
+          setShowAddApp(false);
+          return;
+        }
+      }
+
+      if (platform === Platform.IOS) {
+        // First try App Store numeric ID from metadata.url to avoid scraper
+        // call for existing apps. After scraping, still check canonical saved
+        // packageName/appId because metadata.url is only best-effort shortcut.
+        const existingByStoreUrl =
+          await checkIfIosAppExistsByStoreId(parsedAppId);
+        if (existingByStoreUrl) {
+          toast.success("App already exists!");
+          setApp({
+            id: existingByStoreUrl.packageName,
+            name: existingByStoreUrl.metadata.name,
+          });
+          setShowAddApp(false);
+          return;
+        }
+      }
+
+      const result =
+        platform === Platform.ANDROID
+          ? await getAndroidApp({ appId: parsedAppId })
+          : await getIosApp({ id: parsedAppId });
+
+      if (!result || !result.ok) {
+        toast.error(
+          `Failed to fetch ${prettyOS(platform)} app. ${result?.message}`,
+        );
         return;
       }
-    }
 
-    const result =
-      platform === Platform.ANDROID
-        ? await getAndroidApp({ appId: newAppId })
-        : await getIosApp({ id: newAppId });
-
-    if (!result || !result.ok) {
-      toast.error(
-        `Failed to fetch ${prettyOS(platform)} app. ${result?.message}`
-      );
-      return;
-    }
-
-    // need to do post-scrape check, now we switch to id from appId
-    if (platform === Platform.IOS) {
-      const existing = await checkIfAppExists(result.data?.appId, platform);
-      if (existing) {
-        toast.success("App already exists!");
-        setApp({
-          id: existing.packageName,
-          name: existing.metadata.name,
-        });
-        setShowAddApp(false);
-        return;
+      if (platform === Platform.IOS) {
+        const existing = await checkIfAppExists(result.data?.appId, platform);
+        if (existing) {
+          toast.success("App already exists!");
+          setApp({
+            id: existing.packageName,
+            name: existing.metadata.name,
+          });
+          setShowAddApp(false);
+          return;
+        }
       }
-    }
 
-    const saved = await saveApp(convertToPrismaApp(result.data));
-    if (saved.ok) {
-      toast.success("App added!");
-      setTimeout(() => {
-        setApp({
-          id: saved.data?.packageName || newAppId,
-          name: saved.data?.metadata.name || newAppId,
-        });
-      }, 0);
-      setShowAddApp(false);
-      setNewAppId("");
-    } else {
-      toast.error("Failed to save app to database.");
+      const saved = await saveApp(convertToPrismaApp(result.data));
+      if (saved.ok) {
+        toast.success("App added!");
+        setTimeout(() => {
+          setApp({
+            id: saved.data?.packageName || parsedAppId,
+            name: saved.data?.metadata.name || parsedAppId,
+          });
+        }, 0);
+        setShowAddApp(false);
+        setNewAppId("");
+      } else {
+        toast.error("Failed to save app to database.");
+      }
+    } finally {
+      setIsAddingApp(false);
     }
   }
 
@@ -129,10 +171,10 @@ export default function AddAppForm({
       {showAddApp && (
         <div className="space-y-1 animate-fade-in">
           <Label htmlFor="newAppId">
-            Enter{" "}
+            Paste{" "}
             {platform === Platform.ANDROID
-              ? "Google Play Package Id"
-              : "App Store ID"}
+              ? "Google Play URL or package name"
+              : "App Store URL or app ID"}
           </Label>
           <div className="flex flex-col md:flex-row gap-2 w-3/4">
             <input
@@ -142,13 +184,17 @@ export default function AddAppForm({
               onChange={(e) => setNewAppId(e.target.value)}
               placeholder={`${
                 platform === Platform.ANDROID
-                  ? "e.g. com.whatsapp"
-                  : "e.g. 310633997"
+                  ? "e.g. https://play.google.com/store/apps/details?id=com.whatsapp"
+                  : "e.g. https://apps.apple.com/us/app/uber-request-a-ride/id368677368"
               }`}
               className="w-full border rounded px-3 py-2"
             />
-            <Button type="button" disabled={!newAppId} onClick={handleAddApp}>
-              Add App
+            <Button
+              type="button"
+              disabled={!newAppId.trim() || isAddingApp}
+              onClick={handleAddApp}
+            >
+              {isAddingApp ? "Adding..." : "Add App"}
             </Button>
           </div>
         </div>

--- a/src/app/(signed-in)/capture/new/components/add-task-inputs.tsx
+++ b/src/app/(signed-in)/capture/new/components/add-task-inputs.tsx
@@ -3,7 +3,14 @@ import { Textarea } from "@/components/ui/textarea";
 import { Minus, Plus } from "lucide-react";
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 
-export type TaskCandidate = { id: string; description: string };
+export type TaskCandidate = {
+  id: string;
+  description: string;
+  candidateOrigin?: {
+    candidateTaskAppId: string;
+    taskIndex: number;
+  };
+};
 
 export default function AddTaskInputs({
   setTasks,
@@ -51,8 +58,8 @@ export default function AddTaskInputs({
   const updateTask = (id: string, value: string) => {
     setTasks((prev) =>
       prev.map((t) =>
-        t.id === id ? { ...t, description: value.slice(0, maxLength) } : t
-      )
+        t.id === id ? { ...t, description: value.slice(0, maxLength) } : t,
+      ),
     );
   };
 
@@ -77,7 +84,7 @@ export default function AddTaskInputs({
           )}
 
           <Textarea
-            className="min-h-20"
+            className="min-h-14 resize-none"
             ref={setTaskRef(t.id)}
             value={t.description}
             onChange={(e) => updateTask(t.id, e.target.value)}

--- a/src/app/(signed-in)/capture/new/components/app-gallery.tsx
+++ b/src/app/(signed-in)/capture/new/components/app-gallery.tsx
@@ -1,7 +1,7 @@
 import { Input, InputIcon, InputRoot } from "@/components/ui/input-icon";
 import { Platform } from "@/lib/utils";
 import { useAppSearch } from "@/lib/hooks/app";
-import { Loader2, Search } from "lucide-react";
+import { Check, Loader2, Search } from "lucide-react";
 import { Dispatch, SetStateAction, useMemo, useState } from "react";
 import Image from "next/image";
 import { Label } from "@/components/ui/label";
@@ -50,14 +50,14 @@ export default function AppGallery({
       page: 1,
       allowIOS: true,
     }),
-    [search, platform]
+    [search, platform],
   );
   const { apps: searchApps, loading } = useAppSearch(params);
 
   return (
     <>
       <div className="flex items-center justify-between w-full mt-3">
-        <InputRoot className="w-[50%]">
+        <InputRoot className="w-[100%]">
           <InputIcon>
             <Search size={20} className="text-muted-foreground  " />
           </InputIcon>
@@ -68,7 +68,7 @@ export default function AppGallery({
           />
         </InputRoot>
       </div>
-      <div className="grid grid-cols-6 sm:grid-cols-8 md:grid-cols-12 lg:grid-cols-8 w-full h-full gap-2 lg:gap-4 bg-neutral-100 dark:bg-neutral-800 p-2 rounded-lg">
+      <div className="grid grid-cols-2 gap-2 rounded-lg bg-neutral-100 p-2 dark:bg-neutral-800 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
         {loading ? (
           <>
             <GridPlaceholders prefix="loading" />
@@ -86,39 +86,56 @@ export default function AppGallery({
           </>
         ) : (
           <>
-            {searchApps.map((searchApp) => (
-              <TooltipProvider key={`tooltip-${searchApp.id}`}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <div
-                      className={`flex flex-col items-center content-center justify-center cursor-pointer hover:bg-neutral-400 rounded-lg ${searchApp.metadata.name === app.name ? "bg-neutral-400" : ""}`}
-                      onClick={() =>
-                        setApp({
-                          name: searchApp.metadata.name,
-                          id: searchApp.packageName,
-                        })
-                      }
-                    >
-                      <Image
-                        className="object-cover rounded-xl lg:rounded-2xl mb-1"
-                        key={`img-${searchApp.id}`}
-                        src={searchApp.metadata.icon}
-                        alt={searchApp.metadata.name}
-                        width={40}
-                        height={40}
-                        sizes="100vw"
-                      />
-                      <Label className="text-sm text-center self-center overflow-hidden overflow-ellipsis whitespace-nowrap w-full max-w-full">
-                        {searchApp.metadata.name}
-                      </Label>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>{searchApp.metadata.name}</p>
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            ))}
+            {searchApps.map((searchApp) => {
+              const isSelected = searchApp.packageName === app.id;
+
+              return (
+                <TooltipProvider key={`tooltip-${searchApp.id}`}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div
+                        className={`relative flex min-h-20 cursor-pointer items-center gap-2 rounded-lg border p-2 text-left transition focus-within:ring-2 focus-within:ring-primary hover:border-primary/40 hover:bg-neutral-200 dark:hover:bg-neutral-700 ${
+                          isSelected
+                            ? "border-primary bg-primary/10 ring-2 ring-primary/40"
+                            : "border-transparent"
+                        }`}
+                        onClick={() =>
+                          setApp({
+                            name: searchApp.metadata.name,
+                            id: searchApp.packageName,
+                          })
+                        }
+                      >
+                        {isSelected ? (
+                          <div className="absolute right-1 top-1 flex size-5 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                            <Check className="size-3" />
+                          </div>
+                        ) : null}
+                        <Image
+                          className="shrink-0 rounded-xl object-cover lg:rounded-2xl"
+                          key={`img-${searchApp.id}`}
+                          src={searchApp.metadata.icon}
+                          alt={searchApp.metadata.name}
+                          width={40}
+                          height={40}
+                          sizes="100vw"
+                        />
+                        <Label className="line-clamp-2 min-w-0 flex-1 break-words text-sm leading-tight">
+                          {searchApp.metadata.name}
+                        </Label>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>
+                        {isSelected
+                          ? `${searchApp.metadata.name} selected`
+                          : searchApp.metadata.name}
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              );
+            })}
           </>
         )}
       </div>

--- a/src/lib/actions/app.ts
+++ b/src/lib/actions/app.ts
@@ -282,7 +282,7 @@ export async function getAllApps(): Promise<AppItemList[]> {
  * @returns app
  */
 export async function getAppByPackageName(
-  packageName: string
+  packageName: string,
 ): Promise<App | null> {
   if (!packageName) return null;
 
@@ -308,7 +308,7 @@ export async function getAppByPackageName(
  */
 export async function checkIfAppExists(
   packageName: string,
-  os: Platform
+  os: Platform,
 ): Promise<App | null> {
   if (!packageName) return null;
 
@@ -327,12 +327,43 @@ export async function checkIfAppExists(
 }
 
 /**
+ * Best-effort iOS lookup by numeric App Store ID stored inside metadata.url.
+ * This avoids repeat scraper calls for existing apps, but packageName remains
+ * the canonical app identity after scraping.
+ */
+export async function checkIfIosAppExistsByStoreId(
+  storeId: string,
+): Promise<App | null> {
+  if (!/^\d+$/.test(storeId)) return null;
+
+  try {
+    const app = await prisma.app.findFirst({
+      where: {
+        os: Platform.IOS,
+        metadata: {
+          is: {
+            url: {
+              contains: `/id${storeId}`,
+            },
+          },
+        },
+      },
+    });
+
+    return app;
+  } catch (error) {
+    console.error("Failed to check iOS app by store ID:", error);
+    return null;
+  }
+}
+
+/**
  * Saves an app to the database.
  * @param appData - app data to save
  * @returns app
  */
 export async function saveApp(
-  appData: Prisma.AppCreateInput
+  appData: Prisma.AppCreateInput,
 ): Promise<{ ok: boolean; data: App | null }> {
   if (!appData || !appData.packageName) return { ok: false, data: null };
 

--- a/src/lib/actions/candidate-task-apps.ts
+++ b/src/lib/actions/candidate-task-apps.ts
@@ -38,21 +38,25 @@ const SetCandidateTaskStatusInputSchema = z.object({
 
 const GetCandidateTaskCapturePrefillInputSchema = z.object({
   candidateTaskAppId: ObjectIdSchema,
-  taskIndex: z.number().int().nonnegative(),
+  taskIndex: z.number().int().nonnegative().optional(),
+  taskIndexes: z.array(z.number().int().nonnegative()).min(1).optional(),
 });
 
 export type CandidateTaskCapturePrefill = {
   candidateTaskAppId: string;
-  taskIndex: number;
   platform: string;
   app: {
     name: string;
     id: string;
   };
-  task: {
+  tasks: {
     description: string;
     status: string;
-  };
+    origin: {
+      candidateTaskAppId: string;
+      taskIndex: number;
+    };
+  }[];
 };
 
 /**
@@ -290,9 +294,11 @@ export const setCandidateTaskStatus = async ({
 export const getCandidateTaskCapturePrefill = async ({
   candidateTaskAppId,
   taskIndex,
+  taskIndexes,
 }: {
   candidateTaskAppId: string;
-  taskIndex: number;
+  taskIndex?: number;
+  taskIndexes?: number[];
 }): Promise<ActionPayload<CandidateTaskCapturePrefill>> => {
   const session = await requireAuth();
   if (!session?.user?.id) {
@@ -302,6 +308,7 @@ export const getCandidateTaskCapturePrefill = async ({
   const parsedInput = GetCandidateTaskCapturePrefillInputSchema.safeParse({
     candidateTaskAppId,
     taskIndex,
+    taskIndexes,
   });
   if (!parsedInput.success) {
     return {
@@ -312,6 +319,20 @@ export const getCandidateTaskCapturePrefill = async ({
   }
 
   const input = parsedInput.data;
+  const requestedIndexes = Array.from(
+    new Set(
+      input.taskIndexes ??
+        (input.taskIndex !== undefined ? [input.taskIndex] : []),
+    ),
+  );
+
+  if (requestedIndexes.length === 0) {
+    return {
+      ok: false,
+      message: "No candidate task indexes provided.",
+      data: null,
+    };
+  }
 
   try {
     const candidateTaskApp = await prisma.candidateTaskApp.findUnique({
@@ -327,21 +348,33 @@ export const getCandidateTaskCapturePrefill = async ({
       };
     }
 
-    const task = candidateTaskApp.tasks[input.taskIndex];
-    if (!task) {
-      return {
-        ok: false,
-        message: "Candidate task index is out of range.",
-        data: null,
-      };
-    }
+    const tasks = [];
+    for (const requestedIndex of requestedIndexes) {
+      const task = candidateTaskApp.tasks[requestedIndex];
+      if (!task) {
+        return {
+          ok: false,
+          message: "Candidate task index is out of range.",
+          data: null,
+        };
+      }
 
-    if (task.status === "hidden") {
-      return {
-        ok: false,
-        message: "This candidate task is hidden and cannot be started.",
-        data: null,
-      };
+      if (task.status === "hidden") {
+        return {
+          ok: false,
+          message: "A selected candidate task is hidden and cannot be started.",
+          data: null,
+        };
+      }
+
+      tasks.push({
+        description: task.description,
+        status: task.status,
+        origin: {
+          candidateTaskAppId: candidateTaskApp.id,
+          taskIndex: requestedIndex,
+        },
+      });
     }
 
     return {
@@ -349,16 +382,12 @@ export const getCandidateTaskCapturePrefill = async ({
       message: "Candidate task prefill found.",
       data: {
         candidateTaskAppId: candidateTaskApp.id,
-        taskIndex: input.taskIndex,
         platform: candidateTaskApp.app.os,
         app: {
           name: candidateTaskApp.app.metadata.name,
           id: candidateTaskApp.app.packageName,
         },
-        task: {
-          description: task.description,
-          status: task.status,
-        },
+        tasks,
       },
     };
   } catch (error) {


### PR DESCRIPTION
- add same-app multi-select for candidate tasks into /capture/new

- preserve per-row candidate origins when prefilling multiple tasks

- support App Store and Google Play URLs in add-app input

- add best-effort iOS metadata URL lookup before scraper calls

- improve /capture/new app selection visibility and compact result cards

- tighten candidate badge hover colors and task input sizing
