### PR TITLE
editor annotation fixes

### DIFF
--- a/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/components/canvas.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/components/canvas.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useCallback,
   useContext,
+  useEffect,
   useImperativeHandle,
 } from "react";
 import Konva from "konva";
@@ -27,6 +28,7 @@ export interface CanvasComponentProps {
   };
   redactions: Redaction[];
   mode: "pencil" | "eraser" | "select";
+  onImageStatusChange?: (imageStatus: "loading" | "loaded" | "failed") => void;
 }
 
 export interface CanvasRef {
@@ -34,7 +36,7 @@ export interface CanvasRef {
 }
 
 const CanvasComponent = forwardRef<CanvasRef, CanvasComponentProps>(
-  function CanvasComponent({ screen, redactions, vh }, ref) {
+  function CanvasComponent({ screen, redactions, vh, onImageStatusChange }, ref) {
     const { vhBoxes, rootBounds } = vh;
     const {
       mode,
@@ -59,6 +61,10 @@ const CanvasComponent = forwardRef<CanvasRef, CanvasComponentProps>(
       setIsPanning,
       getRelativePointer,
     } = useRedactStageViewport({ imageSrc: screen.src });
+
+    useEffect(() => {
+      onImageStatusChange?.(imageStatus);
+    }, [imageStatus, onImageStatusChange]);
 
     const updateRect = useCallback(
       (id: string, rect: Partial<Redaction>) => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/components/focus-view.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/components/focus-view.tsx
@@ -8,11 +8,13 @@ export function FocusView({
   vh,
   copied,
   setCopied,
+  onImageStatusChange,
 }: {
   screen: FrameData;
   vh: any;
   copied: Redaction[];
   setCopied: React.Dispatch<React.SetStateAction<Redaction[]>>;
+  onImageStatusChange?: (imageStatus: "loading" | "loaded" | "failed") => void;
 }) {
   return (
     <>
@@ -22,6 +24,7 @@ export function FocusView({
           vh={vh}
           copied={copied}
           setCopied={setCopied}
+          onImageStatusChange={onImageStatusChange}
         />
       </div>
     </>

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/components/redact-screen-canvas.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/components/redact-screen-canvas.tsx
@@ -58,11 +58,13 @@ export default function RedactScreenCanvas({
   vh,
   copied,
   setCopied,
+  onImageStatusChange,
 }: {
   screen: FrameData;
   vh: any;
   copied: Redaction[];
   setCopied: React.Dispatch<React.SetStateAction<Redaction[]>>;
+  onImageStatusChange?: (imageStatus: "loading" | "loaded" | "failed") => void;
 }) {
   const { setValue } = useFormContext<TraceFormData>();
   const [watchRedactions] = useWatch({
@@ -347,6 +349,7 @@ export default function RedactScreenCanvas({
           redactions={redactionsOnScreen}
           vh={{ vhBoxes, rootBounds }}
           mode={mode}
+          onImageStatusChange={onImageStatusChange}
         />
       </div>
     </RedactCanvasContext.Provider>

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/redact-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/redact-screen.tsx
@@ -20,10 +20,17 @@ export interface RedactScreenJumpTarget {
   screenId: string;
 }
 
+type NavigationReadiness = {
+  isBlockingNavigation: boolean;
+  reason?: string;
+};
+
 export default function RedactScreen({
   jumpTarget,
+  onNavigationReadinessChange,
 }: {
   jumpTarget?: RedactScreenJumpTarget | null;
+  onNavigationReadinessChange?: (readiness: NavigationReadiness) => void;
 }) {
   const { getValues } = useFormContext<TraceFormData>();
   const screens = getValues("screens") as FrameData[];
@@ -35,6 +42,59 @@ export default function RedactScreen({
 
   const [focusViewIndex, setFocusViewIndex] = useState<number>(-1);
   const [copied, setCopied] = useState<Redaction[]>([]);
+  const focusedScreen =
+    focusViewIndex > -1 ? screens[focusViewIndex] : undefined;
+  const focusedScreenId = focusedScreen?.id ?? null;
+  const focusedScreenSrc = focusedScreen?.src ?? "";
+
+  React.useEffect(() => {
+    if (focusViewIndex < 0) {
+      onNavigationReadinessChange?.({ isBlockingNavigation: false });
+      return;
+    }
+
+    if (!focusedScreenSrc) {
+      onNavigationReadinessChange?.({
+        isBlockingNavigation: true,
+        reason: "Selected redaction screen image is still loading...",
+      });
+      return;
+    }
+
+    onNavigationReadinessChange?.({
+      isBlockingNavigation: true,
+      reason: "Loading selected redaction screen image...",
+    });
+  }, [
+    focusViewIndex,
+    focusedScreenId,
+    focusedScreenSrc,
+    onNavigationReadinessChange,
+  ]);
+
+  const handleImageStatusChange = useCallback(
+    (imageStatus: "loading" | "loaded" | "failed") => {
+      if (imageStatus === "loading") {
+        onNavigationReadinessChange?.({
+          isBlockingNavigation: true,
+          reason: "Loading selected redaction screen image...",
+        });
+        return;
+      }
+      if (imageStatus === "failed") {
+        onNavigationReadinessChange?.({
+          isBlockingNavigation: true,
+          reason:
+            "Selected redaction screen image failed to load. Refresh or return to upload.",
+        });
+        return;
+      }
+      onNavigationReadinessChange?.({
+        isBlockingNavigation: false,
+      });
+    },
+    [onNavigationReadinessChange],
+  );
 
   const handlePrevious = useCallback(() => {
     const wrappedIndex = (focusViewIndex - 1 + screens.length) % screens.length;
@@ -70,13 +130,14 @@ export default function RedactScreen({
           defaultSize={75}
           className="relative z-20 min-w-0 overflow-hidden"
         >
-          {focusViewIndex > -1 ? (
+          {focusedScreen ? (
             <FocusView
-              key={focusViewIndex}
-              screen={screens[focusViewIndex]}
-              vh={vhs[screens[focusViewIndex].id]}
+              key={focusedScreen.id}
+              screen={focusedScreen}
+              vh={vhs[focusedScreen.id]}
               copied={copied}
               setCopied={setCopied}
+              onImageStatusChange={handleImageStatusChange}
             />
           ) : (
             <div className="flex justify-center items-center w-full h-full">

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/gesture-annotation-editor.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/gesture-annotation-editor.tsx
@@ -60,6 +60,7 @@ export const GestureAnnotationEditor =
       const previousGestureTypeRef = useRef<ScreenGesture["type"]>(
         gesture.type,
       );
+      const localTemplateDescriptionRef = useRef<string | null>(null);
 
       const activeTemplate = useMemo(
         () => getGestureTemplate(gesture.type),
@@ -138,6 +139,7 @@ export const GestureAnnotationEditor =
         const typeChanged = previousType !== gesture.type;
 
         if (!gesture.type) {
+          localTemplateDescriptionRef.current = null;
           setLegacyTemplateHint(false);
           previousGestureTypeRef.current = gesture.type;
           return;
@@ -145,6 +147,7 @@ export const GestureAnnotationEditor =
 
         // If the gesture type is freeform, we need to handle the case where the user changes the type from a template to a freeform
         if (isFreeformGestureType(gesture.type)) {
+          localTemplateDescriptionRef.current = null;
           if (
             typeChanged &&
             hasInitializedTypeRef.current &&
@@ -174,6 +177,7 @@ export const GestureAnnotationEditor =
 
         // If the gesture type is a template, we need to handle the case where the user changes the type from a template to a template
         if (typeChanged && hasInitializedTypeRef.current) {
+          localTemplateDescriptionRef.current = null;
           const defaults = getGestureTemplateDefaultSlots(gesture.type);
           setSlotValues(defaults);
           setLegacyTemplateHint(false);
@@ -187,6 +191,16 @@ export const GestureAnnotationEditor =
           if (templated !== gesture.description) {
             setGesture((prev) => ({ ...prev, description: templated }));
           }
+          previousGestureTypeRef.current = gesture.type;
+          return;
+        }
+
+        if (
+          hasInitializedTypeRef.current &&
+          !typeChanged &&
+          localTemplateDescriptionRef.current === (gesture.description ?? "")
+        ) {
+          localTemplateDescriptionRef.current = null;
           previousGestureTypeRef.current = gesture.type;
           return;
         }
@@ -267,6 +281,7 @@ export const GestureAnnotationEditor =
             nextValues,
           );
           if (nextDescription.length > GESTURE_DESCRIPTION_MAX_LENGTH) return;
+          localTemplateDescriptionRef.current = nextDescription;
           setSlotValues(nextValues);
           if (slot.key === "target") setTargetTouched(true);
           if (slot.key === "goal") setGoalTouched(true);

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/gesture-menu.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/gesture-menu.tsx
@@ -68,7 +68,10 @@ export function GestureMenu({
   const [horizontalOffset, setHorizontalOffset] = useState(0);
   const [verticalOffset, setVerticalOffset] = useState(0);
   const [editorMaxHeight, setEditorMaxHeight] = useState<number | null>(null);
+  const hasSelectedGesture = Boolean(normalizeGestureType(gesture.type));
   const shouldHideEditorForDragPlacement = isPlacingDragPoint(gesture);
+  const shouldShowEditor =
+    hasSelectedGesture && !shouldHideEditorForDragPlacement;
   const isWaitingForDragEndPoint = isAwaitingDragEndPoint(gesture);
   const menuAnchor = getGestureMenuAnchor(position, gesture, canvasSize);
   const lastPlacementAnchorRef = useRef<{
@@ -260,7 +263,7 @@ export function GestureMenu({
       >
         {/* Measure selection row here from ref. Editor overlay is absolutely placed so its out of flow, and does not contribute to parent height. */}
         <div ref={selectionRef} className="relative w-full">
-          {placeTextareaAbove && !shouldHideEditorForDragPlacement && (
+          {placeTextareaAbove && shouldShowEditor && (
             <div
               ref={editorContainerRef}
               className="absolute left-0 w-full overflow-y-auto"
@@ -278,7 +281,7 @@ export function GestureMenu({
             openAbove={placeTextareaAbove}
           />
 
-          {!placeTextareaAbove && !shouldHideEditorForDragPlacement && (
+          {!placeTextareaAbove && shouldShowEditor && (
             <div
               ref={editorContainerRef}
               className="absolute left-0 w-full overflow-y-auto"

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/gesture-menu.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/gesture-menu.tsx
@@ -55,6 +55,7 @@ export function GestureMenu({
   position: { x: number | null; y: number | null };
   transform: { x: number; y: number; scaleX: number; scaleY: number } | null;
 }) {
+  const { gesture, canvasSize } = useContext(GestureContext);
   const ANNOTATION_GAP_PX = 4;
   const MARKER_RADIUS_PX = 16;
   const SAFE_ZONE_MARGIN_PX = 8;
@@ -67,11 +68,15 @@ export function GestureMenu({
   const [horizontalOffset, setHorizontalOffset] = useState(0);
   const [verticalOffset, setVerticalOffset] = useState(0);
   const [editorMaxHeight, setEditorMaxHeight] = useState<number | null>(null);
+  const shouldHideEditorForDragPlacement = isPlacingDragPoint(gesture);
+  const isWaitingForDragEndPoint = isAwaitingDragEndPoint(gesture);
+  const menuAnchor = getGestureMenuAnchor(position, gesture, canvasSize);
   const lastPlacementAnchorRef = useRef<{
     markerX: number;
     markerY: number;
     width: number;
     height: number;
+    hasEditor: boolean;
   } | null>(null);
 
   const updatePlacement = useCallback(() => {
@@ -79,17 +84,13 @@ export function GestureMenu({
     const menuElement = menuRef.current;
     const selectionElement = selectionRef.current;
     const editorElement = editorContainerRef.current;
-    if (
-      !droppableElement ||
-      !menuElement ||
-      !selectionElement ||
-      !editorElement
-    ) {
+    const hasEditor = Boolean(editorElement);
+    if (!droppableElement || !menuElement || !selectionElement) {
       return;
     }
 
-    const markerX = (position.x ?? 0) + (transform?.x ?? 0);
-    const markerY = (position.y ?? 0) + (transform?.y ?? 0);
+    const markerX = (menuAnchor.x ?? 0) + (transform?.x ?? 0);
+    const markerY = (menuAnchor.y ?? 0) + (transform?.y ?? 0);
     const droppableRect = droppableElement.getBoundingClientRect();
     const menuRect = menuElement.getBoundingClientRect();
 
@@ -113,7 +114,6 @@ export function GestureMenu({
     }
 
     const selectionRect = selectionElement.getBoundingClientRect();
-    const editorRect = editorElement.getBoundingClientRect();
     const rootTop = markerY - MARKER_RADIUS_PX;
     const safeTop = margin;
     const safeBottom = Math.max(safeTop, droppableRect.height - margin);
@@ -129,13 +129,16 @@ export function GestureMenu({
       setEditorMaxHeight(nextEditorMaxHeight);
     }
 
-    const boundedEditorHeight = Math.min(
-      editorRect.height,
-      nextEditorMaxHeight,
-    );
+    const boundedEditorHeight = editorElement
+      ? Math.min(
+          editorElement.getBoundingClientRect().height,
+          nextEditorMaxHeight,
+        )
+      : 0;
     const roomBelow = safeBottom - (rootTop + selectionRect.height);
     const roomAbove = rootTop - safeTop;
     const shouldPlaceAbove =
+      hasEditor &&
       roomBelow < boundedEditorHeight + ANNOTATION_GAP_PX &&
       roomAbove > roomBelow;
     const previousAnchor = lastPlacementAnchorRef.current;
@@ -144,13 +147,15 @@ export function GestureMenu({
       markerY,
       width: droppableRect.width,
       height: droppableRect.height,
+      hasEditor,
     };
     const shouldAllowSideFlip =
       !previousAnchor ||
       Math.abs(previousAnchor.markerX - placementAnchor.markerX) > 0.5 ||
       Math.abs(previousAnchor.markerY - placementAnchor.markerY) > 0.5 ||
       Math.abs(previousAnchor.width - placementAnchor.width) > 0.5 ||
-      Math.abs(previousAnchor.height - placementAnchor.height) > 0.5;
+      Math.abs(previousAnchor.height - placementAnchor.height) > 0.5 ||
+      previousAnchor.hasEditor !== placementAnchor.hasEditor;
     if (shouldAllowSideFlip && shouldPlaceAbove !== placeTextareaAbove) {
       setPlaceTextareaAbove(shouldPlaceAbove);
     }
@@ -163,7 +168,9 @@ export function GestureMenu({
       : rootTop;
     const fullBottom = shouldPlaceAbove
       ? rootTop + selectionRect.height
-      : rootTop + selectionRect.height + ANNOTATION_GAP_PX + boundedEditorHeight;
+      : rootTop +
+        selectionRect.height +
+        (hasEditor ? ANNOTATION_GAP_PX + boundedEditorHeight : 0);
 
     let nextVerticalOffset = 0;
     if (fullTop < safeTop) {
@@ -183,8 +190,8 @@ export function GestureMenu({
     editorMaxHeight,
     horizontalOffset,
     placeTextareaAbove,
-    position.x,
-    position.y,
+    menuAnchor.x,
+    menuAnchor.y,
     transform?.x,
     transform?.y,
     verticalOffset,
@@ -193,13 +200,13 @@ export function GestureMenu({
   // Determine whether to place the textarea above or below the marker.
   useLayoutEffect(() => {
     updatePlacement();
-  }, [updatePlacement]);
+  }, [shouldHideEditorForDragPlacement, updatePlacement]);
 
   useEffect(() => {
     const menuElement = menuRef.current;
     const selectionElement = selectionRef.current;
     const editorElement = editorContainerRef.current;
-    if (!menuElement || !selectionElement || !editorElement) {
+    if (!menuElement || !selectionElement) {
       return;
     }
     if (typeof ResizeObserver === "undefined") {
@@ -213,14 +220,16 @@ export function GestureMenu({
     });
     resizeObserver.observe(menuElement);
     resizeObserver.observe(selectionElement);
-    resizeObserver.observe(editorElement);
+    if (editorElement) {
+      resizeObserver.observe(editorElement);
+    }
     window.addEventListener("resize", updatePlacement);
 
     return () => {
       resizeObserver.disconnect();
       window.removeEventListener("resize", updatePlacement);
     };
-  }, [updatePlacement]);
+  }, [shouldHideEditorForDragPlacement, updatePlacement]);
 
   // Focus the description field of the gesture annotation editor
   const focusDescriptionField = () => {
@@ -228,51 +237,62 @@ export function GestureMenu({
   };
 
   return (
-    <div
-      ref={menuRef}
-      className="absolute z-50 ml-2"
-      style={{
-        left: `calc(${position.x ?? 0}px + var(--marker-radius))`,
-        top: `calc(${position.y ?? 0}px - var(--marker-radius))`,
-        transform: `translate3d(${(transform?.x ?? 0) + horizontalOffset}px, ${
-          (transform?.y ?? 0) + verticalOffset
-        }px, 0)`,
-      }}
-    >
-      {/* Measure selection row here from ref. Editor overlay is absolutely placed so its out of flow, and does not contribute to parent height. */}
-      <div ref={selectionRef} className="relative w-full">
-        {placeTextareaAbove && (
-          <div
-            ref={editorContainerRef}
-            className="absolute left-0 w-full overflow-y-auto"
-            style={{
-              bottom: `calc(100% + ${ANNOTATION_GAP_PX}px)`,
-              maxHeight: editorMaxHeight ?? undefined,
-            }}
-          >
-            <GestureAnnotationEditor ref={editorRef} />
+    <>
+      {isWaitingForDragEndPoint ? (
+        <div className="pointer-events-none absolute left-1/2 top-3 z-50 -translate-x-1/2">
+          <div className="inline-flex items-center rounded-md border border-black/20 bg-black/85 px-2 py-1 text-xs font-semibold tracking-wide text-white shadow-sm dark:border-white/25 dark:bg-white/90 dark:text-black">
+            Click end point
           </div>
-        )}
+        </div>
+      ) : null}
 
-        <GestureSelection
-          focusDescriptionField={focusDescriptionField}
-          openAbove={placeTextareaAbove}
-        />
+      <div
+        ref={menuRef}
+        className="absolute z-50 ml-2"
+        style={{
+          left: `calc(${menuAnchor.x ?? 0}px + var(--marker-radius))`,
+          top: `calc(${menuAnchor.y ?? 0}px - var(--marker-radius))`,
+          transform: `translate3d(${(transform?.x ?? 0) + horizontalOffset}px, ${
+            (transform?.y ?? 0) + verticalOffset
+          }px, 0)`,
+          display: isWaitingForDragEndPoint ? "none" : undefined,
+        }}
+      >
+        {/* Measure selection row here from ref. Editor overlay is absolutely placed so its out of flow, and does not contribute to parent height. */}
+        <div ref={selectionRef} className="relative w-full">
+          {placeTextareaAbove && !shouldHideEditorForDragPlacement && (
+            <div
+              ref={editorContainerRef}
+              className="absolute left-0 w-full overflow-y-auto"
+              style={{
+                bottom: `calc(100% + ${ANNOTATION_GAP_PX}px)`,
+                maxHeight: editorMaxHeight ?? undefined,
+              }}
+            >
+              <GestureAnnotationEditor ref={editorRef} />
+            </div>
+          )}
 
-        {!placeTextareaAbove && (
-          <div
-            ref={editorContainerRef}
-            className="absolute left-0 w-full overflow-y-auto"
-            style={{
-              top: `calc(100% + ${ANNOTATION_GAP_PX}px)`,
-              maxHeight: editorMaxHeight ?? undefined,
-            }}
-          >
-            <GestureAnnotationEditor ref={editorRef} />
-          </div>
-        )}
+          <GestureSelection
+            focusDescriptionField={focusDescriptionField}
+            openAbove={placeTextareaAbove}
+          />
+
+          {!placeTextareaAbove && !shouldHideEditorForDragPlacement && (
+            <div
+              ref={editorContainerRef}
+              className="absolute left-0 w-full overflow-y-auto"
+              style={{
+                top: `calc(100% + ${ANNOTATION_GAP_PX}px)`,
+                maxHeight: editorMaxHeight ?? undefined,
+              }}
+            >
+              <GestureAnnotationEditor ref={editorRef} />
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }
 
@@ -287,6 +307,55 @@ export function DroppableArea({ children }: { children: React.ReactNode }) {
 
 function isDragGesture(type: string | null) {
   return normalizeGestureType(type) === GESTURE_TYPES.DRAG;
+}
+
+function isPlacingDragPoint(gesture: ScreenGesture) {
+  return (
+    isDragGesture(gesture.type) &&
+    (gesture.x === null ||
+      gesture.y === null ||
+      gesture.scrollDeltaX === null ||
+      gesture.scrollDeltaY === null)
+  );
+}
+
+function isAwaitingDragEndPoint(gesture: ScreenGesture) {
+  return (
+    isDragGesture(gesture.type) &&
+    gesture.x !== null &&
+    gesture.y !== null &&
+    (gesture.scrollDeltaX === null || gesture.scrollDeltaY === null)
+  );
+}
+
+function getGestureMenuAnchor(
+  position: { x: number | null; y: number | null },
+  gesture: ScreenGesture,
+  canvasSize: { width: number; height: number },
+) {
+  if (
+    !isDragGesture(gesture.type) ||
+    position.x === null ||
+    position.y === null ||
+    gesture.scrollDeltaX === null ||
+    gesture.scrollDeltaY === null
+  ) {
+    return position;
+  }
+
+  const endX =
+    position.x + gesture.scrollDeltaX * Math.max(canvasSize.width, 1);
+  const endY =
+    position.y + gesture.scrollDeltaY * Math.max(canvasSize.height, 1);
+
+  if (endX <= position.x) {
+    return position;
+  }
+
+  return {
+    x: endX,
+    y: endY,
+  };
 }
 
 export function DraggableMarker({

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/gesture-selection.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/gesture-selection.tsx
@@ -11,6 +11,7 @@ import {
   Command,
   CommandEmpty,
   CommandGroup,
+  CommandInput,
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
@@ -30,11 +31,12 @@ import {
   GestureOption,
   COMMAND_ITEM_CLASS,
   COMMAND_LIST_CLASS,
+  flattenGestureOptions,
   findGestureOption,
   normalizeGestureType,
   POPOVER_CONTENT_CLASS,
 } from "@/lib/utils/gesture-options";
-import { GESTURE_TYPES } from "@/lib/utils/gesture-types";
+import { GESTURE_GROUP_TYPES, GESTURE_TYPES } from "@/lib/utils/gesture-types";
 import { GestureContext } from "./gesture-menu";
 
 export function GestureSelection({
@@ -47,6 +49,7 @@ export function GestureSelection({
   const { gesture, setGesture, gestureOptions } = useContext(GestureContext);
   const [open, setOpen] = useState(gesture.type === null);
   const [value, setValue] = useState<string>(gesture.type ?? "");
+  const [search, setSearch] = useState("");
   const [hoveredOption, setHoveredOption] = useState<string | null>(null);
 
   const toStoredGestureType = (raw: string): ScreenGesture["type"] | null => {
@@ -60,6 +63,13 @@ export function GestureSelection({
   }, [gesture.type]);
 
   const selectedStoredType = toStoredGestureType(value);
+  const concreteGestureOptions = flattenGestureOptions(gestureOptions).filter(
+    (option) =>
+      option.value !== GESTURE_GROUP_TYPES.SWIPE &&
+      option.value !== GESTURE_GROUP_TYPES.ZOOM &&
+      option.value !== GESTURE_GROUP_TYPES.ROTATE,
+  );
+  const isSearching = search.trim().length > 0;
   const dragHelperText =
     selectedStoredType === GESTURE_TYPES.DRAG
       ? gesture.x === null || gesture.y === null
@@ -129,107 +139,148 @@ export function GestureSelection({
           </Button>
         </PopoverTrigger>
         <PopoverContent
-          className={POPOVER_CONTENT_CLASS}
+          className={cn(
+            POPOVER_CONTENT_CLASS,
+            "group/gesture-popover",
+          )}
           side={openAbove ? "top" : "bottom"}
           align="start"
-          sideOffset={4}
-          avoidCollisions={false}
+          sideOffset={6}
+          avoidCollisions
         >
-          <Command>
-            <CommandList className={COMMAND_LIST_CLASS}>
+          <Command className="group-data-[side=top]/gesture-popover:flex-col-reverse">
+            <CommandInput
+              value={search}
+              onValueChange={setSearch}
+              placeholder="Search gestures..."
+            />
+            <CommandList
+              id="gesture-selection-list"
+              className={COMMAND_LIST_CLASS}
+            >
               <CommandEmpty>No gesture found.</CommandEmpty>
               <CommandGroup>
-                {gestureOptions.map((option) =>
-                  option.subGestures ? (
-                    <CommandItem
-                      key={option.value}
-                      value={option.value}
-                      onMouseEnter={() => {
-                        setHoveredOption(option.value);
-                      }}
-                      onMouseLeave={() => {
-                        setHoveredOption(null);
-                      }}
-                      className={cn(COMMAND_ITEM_CLASS, "cursor-pointer")}
-                    >
-                      <div
-                        id={`${option.value}-label`}
-                        className={`inline-flex w-full items-center gap-2 transition-transform duration-200 ${
-                          hoveredOption === option.value
-                            ? "-translate-x-full"
-                            : "translate-x-0"
-                        }`}
+                {isSearching
+                  ? concreteGestureOptions.map((option) => (
+                      <CommandItem
+                        key={option.value}
+                        value={`${option.label} ${option.value}`}
+                        className={cn(COMMAND_ITEM_CLASS, "cursor-pointer")}
+                        onSelect={() => {
+                          setValue(option.value);
+                          setSearch("");
+                          setOpen(false);
+                          focusDescriptionField();
+                        }}
                       >
-                        {option.icon}
-                        {option.label}
-                      </div>
-                      {/* Sub-gesture hidden menu shown on hover */}
-                      <div
-                        id={`${option.value}-sub-gestures`}
-                        className={`absolute w-full inset-0 flex justify-center items-center transition-transform duration-200 ${
-                          hoveredOption === option.value
-                            ? "translate-x-0"
-                            : "translate-x-full"
-                        }`}
-                      >
-                        {option.subGestures.map((subOption: GestureOption) => (
-                          <TooltipProvider
-                            key={subOption.value}
-                            delayDuration={0}
+                        <span className="inline-flex items-center gap-2">
+                          {value === option.value ? (
+                            <Check className={cn("h-4 w-4", "opacity-100")} />
+                          ) : (
+                            option.icon
+                          )}
+                          {option.label}
+                        </span>
+                      </CommandItem>
+                    ))
+                  : gestureOptions.map((option) =>
+                      option.subGestures ? (
+                        <CommandItem
+                          key={option.value}
+                          value={option.value}
+                          onMouseEnter={() => {
+                            setHoveredOption(option.value);
+                          }}
+                          onMouseLeave={() => {
+                            setHoveredOption(null);
+                          }}
+                          className={cn(COMMAND_ITEM_CLASS, "cursor-pointer")}
+                        >
+                          <div
+                            id={`${option.value}-label`}
+                            className={`inline-flex w-full items-center gap-2 transition-transform duration-200 ${
+                              hoveredOption === option.value
+                                ? "-translate-x-full"
+                                : "translate-x-0"
+                            }`}
                           >
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <button
-                                  className="w-full cursor-pointer"
-                                  onClick={() => {
-                                    setValue(subOption.value);
-                                    setOpen(false);
-                                    focusDescriptionField();
-                                  }}
+                            {option.icon}
+                            {option.label}
+                          </div>
+                          {/* Sub-gesture hidden menu shown on hover */}
+                          <div
+                            id={`${option.value}-sub-gestures`}
+                            className={`absolute inset-0 flex w-full items-center justify-center transition-transform duration-200 ${
+                              hoveredOption === option.value
+                                ? "translate-x-0"
+                                : "translate-x-full"
+                            }`}
+                          >
+                            {option.subGestures.map(
+                              (subOption: GestureOption) => (
+                                <TooltipProvider
+                                  key={subOption.value}
+                                  delayDuration={0}
                                 >
-                                  <span className="inline-flex items-center gap-2">
-                                    {value === subOption.value ? (
-                                      <Check
-                                        className={cn("h-4 w-4", "opacity-100")}
-                                      />
-                                    ) : (
-                                      subOption.icon
-                                    )}
-                                  </span>
-                                </button>
-                              </TooltipTrigger>
-                              <TooltipContent side="top">
-                                {subOption.label}
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        ))}
-                      </div>
-                    </CommandItem>
-                  ) : (
-                    <CommandItem
-                      key={option.value}
-                      value={option.value}
-                      className={cn(COMMAND_ITEM_CLASS, "cursor-pointer")}
-                      onSelect={(currentValue) => {
-                        const selected =
-                          currentValue === value ? "" : currentValue;
-                        const normalized = normalizeGestureType(selected);
-                        setValue(normalized ?? selected);
-                        setOpen(false);
-                        focusDescriptionField();
-                      }}
-                    >
-                      <span className="inline-flex items-center gap-2">
-                        {value === option.value ? (
-                          <Check className={cn("h-4 w-4", "opacity-100")} />
-                        ) : (
-                          option.icon
-                        )}
-                        {option.label}
-                      </span>
-                    </CommandItem>
-                  ),
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <button
+                                        className="w-full cursor-pointer"
+                                        onClick={() => {
+                                          setValue(subOption.value);
+                                          setSearch("");
+                                          setOpen(false);
+                                          focusDescriptionField();
+                                        }}
+                                      >
+                                        <span className="inline-flex items-center gap-2">
+                                          {value === subOption.value ? (
+                                            <Check
+                                              className={cn(
+                                                "h-4 w-4",
+                                                "opacity-100",
+                                              )}
+                                            />
+                                          ) : (
+                                            subOption.icon
+                                          )}
+                                        </span>
+                                      </button>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="top">
+                                      {subOption.label}
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              ),
+                            )}
+                          </div>
+                        </CommandItem>
+                      ) : (
+                        <CommandItem
+                          key={option.value}
+                          value={option.value}
+                          className={cn(COMMAND_ITEM_CLASS, "cursor-pointer")}
+                          onSelect={(currentValue) => {
+                            const selected =
+                              currentValue === value ? "" : currentValue;
+                            const normalized = normalizeGestureType(selected);
+                            setValue(normalized ?? selected);
+                            setSearch("");
+                            setOpen(false);
+                            focusDescriptionField();
+                          }}
+                        >
+                          <span className="inline-flex items-center gap-2">
+                            {value === option.value ? (
+                              <Check className={cn("h-4 w-4", "opacity-100")} />
+                            ) : (
+                              option.icon
+                            )}
+                            {option.label}
+                          </span>
+                        </CommandItem>
+                      ),
                 )}
               </CommandGroup>
             </CommandList>

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/gesture-selection.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/gesture-selection.tsx
@@ -77,7 +77,7 @@ export function GestureSelection({
         const wasDrag = prev.type === GESTURE_TYPES.DRAG;
         const isDrag = storedType === GESTURE_TYPES.DRAG;
         const isGestureTypeTransition = prev.type !== storedType;
-        const resetDragPoints = isGestureTypeTransition && (wasDrag || isDrag);
+        const resetDragPoints = isGestureTypeTransition && isDrag;
 
         return {
           ...prev,

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -50,6 +50,7 @@ export function useIosScrubPreview({
   const scrubDisplayRafRef = useRef<number | null>(null);
   const previewSwapTimeoutRef = useRef<number | null>(null);
   const lastCommittedVideoTimeRef = useRef<number | null>(null);
+  const activePreviewFrameSrcRef = useRef<string | null>(null);
 
   const [scrubPreviewTime, setScrubPreviewTime] = useState<number | null>(null);
   const [pausedPreviewTime, setPausedPreviewTime] = useState<number | null>(
@@ -84,6 +85,10 @@ export function useIosScrubPreview({
   const displayedTimelineTime = scrubPreviewTime ?? currentTime;
   const hasPreviewOverlay =
     displayedPreviewFrameSrc !== null || incomingPreviewFrameSrc !== null;
+
+  useEffect(() => {
+    activePreviewFrameSrcRef.current = activePreviewFrameSrc;
+  }, [activePreviewFrameSrc]);
 
   // Reset all preview frame state. Used by bootstrap on video reload and live-photo start.
   const resetPreviewFrames = useCallback(() => {
@@ -241,6 +246,10 @@ export function useIosScrubPreview({
   }, [activePreviewFrameSrc, displayedPreviewFrameSrc]);
 
   const handleIncomingPreviewLoad = useCallback((loadedSrc: string) => {
+    if (loadedSrc !== activePreviewFrameSrcRef.current) {
+      return;
+    }
+
     setIsIncomingPreviewVisible(true);
 
     if (previewSwapTimeoutRef.current !== null) {
@@ -248,6 +257,11 @@ export function useIosScrubPreview({
     }
 
     previewSwapTimeoutRef.current = window.setTimeout(() => {
+      if (loadedSrc !== activePreviewFrameSrcRef.current) {
+        previewSwapTimeoutRef.current = null;
+        return;
+      }
+
       setDisplayedPreviewFrameSrc(loadedSrc);
       setIncomingPreviewFrameSrc((currentIncomingSrc) =>
         currentIncomingSrc === loadedSrc ? null : currentIncomingSrc,

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -248,7 +248,7 @@ export function useIosScrubPreview({
 
     setIncomingPreviewFrameSrc(activePreviewFrameSrc);
     setIsIncomingPreviewVisible(false);
-  }, [activePreviewFrameSrc, displayedPreviewFrameSrc, incomingPreviewFrameSrc]);
+  }, [activePreviewFrameSrc, displayedPreviewFrameSrc]);
 
   const handleIncomingPreviewLoad = useCallback((loadedSrc: string) => {
     if (loadedSrc !== activePreviewFrameSrcRef.current) {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -71,12 +71,16 @@ export function useIosScrubPreview({
   );
 
   const activePreviewFrameSrc = useMemo(() => {
+    const sourceTime = scrubPreviewTime ?? pausedPreviewTime;
+    const selected =
+      sourceTime !== null ? getNearestPreviewThumbnail(sourceTime) : null;
+
     if (scrubPreviewTime !== null) {
-      return getNearestPreviewThumbnail(scrubPreviewTime)?.src ?? null;
+      return selected?.src ?? null;
     }
 
     if (pausedPreviewTime !== null) {
-      return getNearestPreviewThumbnail(pausedPreviewTime)?.src ?? null;
+      return selected?.src ?? null;
     }
 
     return null;
@@ -176,6 +180,7 @@ export function useIosScrubPreview({
         pendingSeekTimeRef.current = null;
         const scrubTargetTime = scrubPreviewTimeRef.current;
         if (
+          !isScrubPreviewActiveRef.current &&
           scrubTargetTime !== null &&
           Math.abs(video.currentTime - scrubTargetTime) <= 0.001
         ) {
@@ -243,7 +248,7 @@ export function useIosScrubPreview({
 
     setIncomingPreviewFrameSrc(activePreviewFrameSrc);
     setIsIncomingPreviewVisible(false);
-  }, [activePreviewFrameSrc, displayedPreviewFrameSrc]);
+  }, [activePreviewFrameSrc, displayedPreviewFrameSrc, incomingPreviewFrameSrc]);
 
   const handleIncomingPreviewLoad = useCallback((loadedSrc: string) => {
     if (loadedSrc !== activePreviewFrameSrcRef.current) {
@@ -422,6 +427,10 @@ export function useIosScrubPreview({
 
   const handleScrubActiveChange = useCallback((active: boolean) => {
     isScrubPreviewActiveRef.current = active;
+
+    if (active) {
+      setPausedPreviewTime(null);
+    }
 
     if (!active && scrubPreviewTimeRef.current === null) {
       pendingScrubDisplayTimeRef.current = null;

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/video-preview-overlay.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/video-preview-overlay.tsx
@@ -30,7 +30,7 @@ export function VideoPreviewOverlay({
         crossOrigin="anonymous"
         preload="auto"
         className={cn(
-          "max-w-full max-h-full rounded-lg object-contain transition-opacity",
+          "relative z-0 max-w-full max-h-full rounded-lg object-contain transition-opacity",
           hasPreviewOverlay ? "opacity-0" : "opacity-100",
         )}
         controls={false}
@@ -44,7 +44,7 @@ export function VideoPreviewOverlay({
           fill
           unoptimized
           sizes="100vw"
-          className="pointer-events-none absolute inset-0 h-full w-full rounded-lg object-contain"
+          className="pointer-events-none absolute inset-0 z-10 h-full w-full rounded-lg object-contain"
         />
       ) : null}
       {incomingPreviewFrameSrc ? (
@@ -57,7 +57,7 @@ export function VideoPreviewOverlay({
           sizes="100vw"
           onLoad={() => onIncomingPreviewLoad(incomingPreviewFrameSrc)}
           className={cn(
-            "pointer-events-none absolute inset-0 h-full w-full rounded-lg object-contain transition-opacity duration-75",
+            "pointer-events-none absolute inset-0 z-20 h-full w-full rounded-lg object-contain transition-opacity duration-75",
             isIncomingPreviewVisible ? "opacity-100" : "opacity-0",
           )}
         />

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -58,6 +58,11 @@ enum TraceSteps {
   Review = 2,
 }
 
+type EditorNavigationReadiness = {
+  isBlockingNavigation: boolean;
+  reason?: string;
+};
+
 const FEEDBACK_STEP_ORDER = [
   TraceSteps.Capture,
   TraceSteps.Redact,
@@ -76,6 +81,11 @@ export default function Page() {
     DraftFetchResults.LOADING,
   );
   const [files, setFiles] = useState<ListedFiles[]>([]);
+  const [isFetchingVideoFiles, setIsFetchingVideoFiles] = useState(true);
+  const [redactReadiness, setRedactReadiness] =
+    useState<EditorNavigationReadiness>({
+      isBlockingNavigation: false,
+    });
   const [navRef, { height }] = useMeasure();
   const router = useRouter();
   const [feedbackOverrides, setFeedbackOverrides] = useState<{
@@ -219,17 +229,34 @@ export default function Page() {
   useEffect(() => {
     if (!captureId) return;
 
+    let isCurrentFetch = true;
+
     const fetchVideoFiles = async () => {
       try {
+        setIsFetchingVideoFiles(true);
         const result = await fileFetcher(["", captureId]);
+        if (!isCurrentFetch) {
+          return;
+        }
         setFiles(result);
       } catch (error) {
+        if (!isCurrentFetch) {
+          return;
+        }
         console.error("Failed to fetch video files:", error);
         setFiles([]);
+      } finally {
+        if (isCurrentFetch) {
+          setIsFetchingVideoFiles(false);
+        }
       }
     };
 
     fetchVideoFiles();
+
+    return () => {
+      isCurrentFetch = false;
+    };
   }, [captureId]);
 
   const isAutosavingRef = useRef(false);
@@ -463,7 +490,71 @@ export default function Page() {
     [effectiveSelectedFeedbackStep],
   );
 
+  const activeStepReadiness = useMemo<EditorNavigationReadiness>(() => {
+    if (stepIndex === TraceSteps.Capture) {
+      if (draftFetchResult === DraftFetchResults.LOADING) {
+        return {
+          isBlockingNavigation: true,
+          reason: "Loading saved draft data...",
+        };
+      }
+      if (draftFetchResult === DraftFetchResults.ERROR) {
+        return {
+          isBlockingNavigation: true,
+          reason: "Draft data failed to load. Refresh or return to upload.",
+        };
+      }
+      if (isFetchingVideoFiles) {
+        return {
+          isBlockingNavigation: true,
+          reason: "Loading uploaded recording...",
+        };
+      }
+      if (watchedScreens.length === 0) {
+        return {
+          isBlockingNavigation: true,
+          reason: "Preparing screen images...",
+        };
+      }
+      if (watchedScreens.some((screen) => !screen.src)) {
+        return {
+          isBlockingNavigation: true,
+          reason: "Preparing screen images...",
+        };
+      }
+    }
+
+    if (stepIndex === TraceSteps.Redact) {
+      return redactReadiness;
+    }
+
+    if (
+      stepIndex === TraceSteps.Review &&
+      watchedScreens.some((screen) => !screen.src)
+    ) {
+      return {
+        isBlockingNavigation: true,
+        reason: "Screen images are still being prepared.",
+      };
+    }
+
+    return { isBlockingNavigation: false };
+  }, [
+    draftFetchResult,
+    isFetchingVideoFiles,
+    redactReadiness,
+    stepIndex,
+    watchedScreens,
+  ]);
+
   const handleNext = async () => {
+    if (activeStepReadiness.isBlockingNavigation) {
+      toast.error(
+        activeStepReadiness.reason ?? "Editor assets are still loading.",
+      );
+      return;
+    }
+
     setIsSubmitting(true);
     // check zod schema validation for each step
     if (stepIndex === TraceSteps.Capture) {
@@ -618,7 +709,12 @@ export default function Page() {
           />
         );
       case 1:
-        return <RedactScreen jumpTarget={redactScreenJumpTarget} />;
+        return (
+          <RedactScreen
+            jumpTarget={redactScreenJumpTarget}
+            onNavigationReadinessChange={setRedactReadiness}
+          />
+        );
       case 2:
         return <Review capture={capture} />;
       default:
@@ -790,14 +886,26 @@ export default function Page() {
                     >
                       Back
                     </Button>
-                    {
-                      <Button onClick={handleNext} disabled={isSubmitting}>
+                    <div className="flex flex-col items-end gap-1">
+                      <Button
+                        onClick={handleNext}
+                        disabled={
+                          isSubmitting ||
+                          activeStepReadiness.isBlockingNavigation
+                        }
+                      >
                         {isSubmitting && (
                           <Loader2 className="size-4 animate-spin" />
                         )}
                         {stepIndex < TraceSteps.Review ? "Next" : "Finish"}
                       </Button>
-                    }
+                      {activeStepReadiness.isBlockingNavigation &&
+                      activeStepReadiness.reason ? (
+                        <p className="max-w-64 text-right text-xs text-muted-foreground">
+                          {activeStepReadiness.reason}
+                        </p>
+                      ) : null}
+                    </div>
                   </div>
                 </nav>
               </>


### PR DESCRIPTION
- **Gate editor next actions on required image readiness**
- **fix: prevent gesture annotation slot edits from moving cursor**
- **fix: prevent drag gesture controls from blocking point selection**
- **feat: add searchable gesture selection Add search to the repair gesture picker while preserving the existing grouped browse UI. Show concrete gesture results for typed queries and keep the search field nearest the trigger when the popover opens above or below.**
- **fix: layer iOS scrub preview above video Add explicit z-index ordering for the iOS scrub video and preview frames so generated preview thumbnails stay above the underlying video during scrub transitions.**
- **fix: ignore stale iOS scrub preview loads Track the currently intended preview thumbnail and ignore late image load events from older scrub targets. Recheck before promoting incoming previews so stale thumbnails cannot replace the active scrub preview.**
