### PR TITLE
fix(annotate): stop the feedback jump from stealing focus on every keystroke

### DIFF
--- a/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/redact-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/redact-screen.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import {
@@ -110,8 +110,18 @@ export default function RedactScreen({
   useHotkeys("right", handleNext);
   useHotkeys("tab", handleNext);
 
+  // Apply each checklist jump exactly once. `screens` is read via `getValues`
+  // here, so it happens to keep a stable identity and this effect does not
+  // currently re-fire on form writes — unlike the repair step, where the same
+  // effect without this guard re-applied the jump on every keystroke. Guarding
+  // anyway so the behaviour does not depend on that accident.
+  const appliedJumpNonceRef = useRef<number | null>(null);
+
   React.useEffect(() => {
     if (!jumpTarget) {
+      return;
+    }
+    if (appliedJumpNonceRef.current === jumpTarget.nonce) {
       return;
     }
 
@@ -119,6 +129,7 @@ export default function RedactScreen({
       (screen) => screen.id === jumpTarget.screenId,
     );
     if (targetIndex >= 0) {
+      appliedJumpNonceRef.current = jumpTarget.nonce;
       setFocusViewIndex(targetIndex);
     }
   }, [jumpTarget, screens]);

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -7,7 +7,7 @@ import { Filmstrip } from "../filmstrip";
 import FrameTimeline from "./extract-frames-timeline";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { extractVideoFrame } from "../../util";
+import { extractVideoFrame, useFormFieldKeyPressGuard } from "../../util";
 import { FrameData, Redaction, TraceFormData } from "../../../types";
 import { ListedFiles } from "@/lib/actions";
 import { ScreenGesture } from "@prisma/client";
@@ -60,6 +60,7 @@ export function RepairScreenIOS({
   );
 
   const videoRef = useRef<HTMLVideoElement>(null);
+  const didKeyPressStartInFormField = useFormFieldKeyPressGuard();
 
   const videoFiles = useMemo(() => {
     const regexRule = /\.(mp4|mov)$/;
@@ -222,11 +223,18 @@ export function RepairScreenIOS({
   useHotkeys(
     "c",
     (e) => {
+      // Bound to keyup, so the release can outlive the field it was typed into:
+      // if a form write moved the focused screen mid-press, the annotation
+      // editor is already gone and this event reads as a bare workspace
+      // keypress. Trust the keydown's target instead.
+      if (didKeyPressStartInFormField("c")) {
+        return;
+      }
       e.preventDefault();
       handleCaptureFrame();
     },
     { keyup: true },
-    [handleCaptureFrame],
+    [didKeyPressStartInFormField, handleCaptureFrame],
   );
 
   return (

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -91,8 +91,8 @@ export function RepairScreenIOS({
   });
 
   // Bootstrap: load video, populate screens, expose duration + thumbnails.
-  const { videoDuration, thumbnails, previewThumbnails } = useIosVideoBootstrap(
-    {
+  const { videoDuration, thumbnails, previewThumbnails, isVideoReady } =
+    useIosVideoBootstrap({
       videoRef,
       videoFiles,
       draftFetchResult,
@@ -100,8 +100,7 @@ export function RepairScreenIOS({
       setValue,
       onResetPreviewFrames,
       registerScreenUrl,
-    },
-  );
+    });
 
   // Playback: isPlaying, currentTime, live-photo replay window.
   const {
@@ -157,24 +156,24 @@ export function RepairScreenIOS({
   // close together and would override the jump that asked for this seek.
   useEffect(() => {
     registerSeekToTime((timestamp) => {
-      // handleSetTime clamps into [0, videoDuration], and videoDuration is 0
-      // until the recording's metadata loads. Seeking now would silently park
-      // the playhead at 0 and never correct itself, because a jump applies only
-      // once. Hold the timestamp and let the effect below place it instead.
-      if (videoDuration <= 0) {
+      // Bootstrap seeks the live video element while extracting frames — the
+      // warmup grab alone drags it to 0.1s — and the `seeked` listener writes
+      // that back over currentTime. Seeking before it finishes gets undone, and
+      // a jump applies only once, so it never self-corrects. Hold it instead.
+      if (!isVideoReady) {
         pendingJumpSeekRef.current = timestamp;
         return;
       }
       handleSetTime(timestamp, { syncFocus: false });
     });
     return () => registerSeekToTime(null);
-  }, [handleSetTime, registerSeekToTime, videoDuration]);
+  }, [handleSetTime, isVideoReady, registerSeekToTime]);
 
-  // Place a jump seek that arrived before the recording was ready. Reachable
-  // whenever the step is re-entered with a jump still armed: both this component
-  // and the video remount, so the jump applies while videoDuration is still 0.
+  // Place a jump seek that arrived while the recording was still loading.
+  // Reachable whenever the step is re-entered with a jump still armed: this
+  // component and the video both remount, so the jump lands mid-bootstrap.
   useEffect(() => {
-    if (videoDuration <= 0) {
+    if (!isVideoReady) {
       return;
     }
     const pendingSeek = pendingJumpSeekRef.current;
@@ -183,7 +182,7 @@ export function RepairScreenIOS({
     }
     pendingJumpSeekRef.current = null;
     handleSetTime(pendingSeek, { syncFocus: false });
-  }, [handleSetTime, videoDuration]);
+  }, [handleSetTime, isVideoReady]);
 
   // Now that scrub-preview exists, point the lazy refs at the real callbacks.
   useEffect(() => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -35,7 +35,8 @@ export function RepairScreenIOS({
   os: Platform;
   draftFetchResult: DraftFetchResults;
 }) {
-  const { focusViewIndex, setFocusViewIndex } = useNavigation();
+  const { focusViewIndex, setFocusViewIndex, registerSeekToTime } =
+    useNavigation();
   const { setValue } = useFormContext<TraceFormData>();
   const { register: registerScreenUrl } = useScreenBlobRegistry();
   const [watchScreens, watchGestures, watchRedactions] = useWatch({
@@ -147,6 +148,17 @@ export function RepairScreenIOS({
     setIsLivePhotoActive,
     syncFocusToTimestamp,
   });
+
+  // Let a jump to a screen (feedback checklist chip) carry the playhead with it.
+  // `syncFocus: false` matters: handleSetTime otherwise re-derives focus from the
+  // nearest screen timestamp, which lands on a neighbour when two screens sit
+  // close together and would override the jump that asked for this seek.
+  useEffect(() => {
+    registerSeekToTime((timestamp) =>
+      handleSetTime(timestamp, { syncFocus: false }),
+    );
+    return () => registerSeekToTime(null);
+  }, [handleSetTime, registerSeekToTime]);
 
   // Now that scrub-preview exists, point the lazy refs at the real callbacks.
   useEffect(() => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -62,6 +62,8 @@ export function RepairScreenIOS({
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const didKeyPressStartInFormField = useFormFieldKeyPressGuard();
+  // Holds a jump's seek target while the recording is still loading.
+  const pendingJumpSeekRef = useRef<number | null>(null);
 
   const videoFiles = useMemo(() => {
     const regexRule = /\.(mp4|mov)$/;
@@ -154,11 +156,34 @@ export function RepairScreenIOS({
   // nearest screen timestamp, which lands on a neighbour when two screens sit
   // close together and would override the jump that asked for this seek.
   useEffect(() => {
-    registerSeekToTime((timestamp) =>
-      handleSetTime(timestamp, { syncFocus: false }),
-    );
+    registerSeekToTime((timestamp) => {
+      // handleSetTime clamps into [0, videoDuration], and videoDuration is 0
+      // until the recording's metadata loads. Seeking now would silently park
+      // the playhead at 0 and never correct itself, because a jump applies only
+      // once. Hold the timestamp and let the effect below place it instead.
+      if (videoDuration <= 0) {
+        pendingJumpSeekRef.current = timestamp;
+        return;
+      }
+      handleSetTime(timestamp, { syncFocus: false });
+    });
     return () => registerSeekToTime(null);
-  }, [handleSetTime, registerSeekToTime]);
+  }, [handleSetTime, registerSeekToTime, videoDuration]);
+
+  // Place a jump seek that arrived before the recording was ready. Reachable
+  // whenever the step is re-entered with a jump still armed: both this component
+  // and the video remount, so the jump applies while videoDuration is still 0.
+  useEffect(() => {
+    if (videoDuration <= 0) {
+      return;
+    }
+    const pendingSeek = pendingJumpSeekRef.current;
+    if (pendingSeek === null) {
+      return;
+    }
+    pendingJumpSeekRef.current = null;
+    handleSetTime(pendingSeek, { syncFocus: false });
+  }, [handleSetTime, videoDuration]);
 
   // Now that scrub-preview exists, point the lazy refs at the real callbacks.
   useEffect(() => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
@@ -35,6 +35,13 @@ interface UseIosVideoBootstrapResult {
   videoDuration: number;
   thumbnails: PreviewThumbnail[];
   previewThumbnails: PreviewThumbnail[];
+  /**
+   * False until this hook has finished with the video element. Bootstrap seeks
+   * the live element while extracting frames, so anything that wants to place
+   * the playhead has to wait for this — a seek performed earlier gets dragged
+   * away by the warmup extraction.
+   */
+  isVideoReady: boolean;
 }
 
 export function useIosVideoBootstrap({
@@ -52,6 +59,7 @@ export function useIosVideoBootstrap({
   const isProcessingRef = useRef(false);
 
   const [videoDuration, setVideoDuration] = useState(0);
+  const [isVideoReady, setIsVideoReady] = useState(false);
   const [thumbnails, setThumbnails] = useState<PreviewThumbnail[]>([]);
   const [previewThumbnails, setPreviewThumbnails] = useState<PreviewThumbnail[]>(
     [],
@@ -87,6 +95,7 @@ export function useIosVideoBootstrap({
       }
       try {
         isProcessingRef.current = true;
+        setIsVideoReady(false);
         revokeBlobUrls(thumbnailObjectUrlsRef.current);
         revokeBlobUrls(previewThumbnailObjectUrlsRef.current);
         thumbnailObjectUrlsRef.current = [];
@@ -194,6 +203,9 @@ export function useIosVideoBootstrap({
           "screens",
           draftScreens.sort((a, b) => a.timestamp - b.timestamp),
         );
+        // Done seeking the live element. Anything holding a playhead position
+        // can place it now without bootstrap dragging it away.
+        setIsVideoReady(true);
       } catch (e) {
         console.error("Error loading video blob:", e);
         toast.error("Error loading video for frame extraction");
@@ -223,5 +235,6 @@ export function useIosVideoBootstrap({
     videoDuration,
     thumbnails,
     previewThumbnails,
+    isVideoReady,
   };
 }

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -206,8 +207,19 @@ export default function RepairScreen({
     [focusViewIndex, handleDeleteScreen],
   );
 
+  // A checklist jump must apply exactly once per click. `screens` stays in the
+  // deps so a jump requested before the screens finish loading still lands, but
+  // it cannot be used to detect a *new* jump: react-hook-form broadcasts a deep
+  // clone of the form on every write, so `useWatch` hands back a fresh `screens`
+  // array on every keystroke. Without the nonce guard, each keystroke re-applied
+  // the last jump and yanked focus off whatever screen was being edited.
+  const appliedJumpNonceRef = useRef<number | null>(null);
+
   React.useEffect(() => {
     if (!jumpTarget) {
+      return;
+    }
+    if (appliedJumpNonceRef.current === jumpTarget.nonce) {
       return;
     }
 
@@ -215,6 +227,7 @@ export default function RepairScreen({
       (screen) => screen.id === jumpTarget.screenId,
     );
     if (targetIndex >= 0) {
+      appliedJumpNonceRef.current = jumpTarget.nonce;
       setFocusViewIndex(targetIndex);
     }
   }, [jumpTarget, screens]);

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
@@ -32,6 +32,12 @@ interface NavigationContextType {
   handleDeleteScreen: (index: number) => void;
   focusViewIndex: number;
   setFocusViewIndex: (index: number) => void;
+  /**
+   * Lets a platform with a scrubbable recording hand up a seek function, so an
+   * explicit jump to a screen can move the playhead with it. Pass `null` to
+   * unregister. Android has no recording to scrub and never registers.
+   */
+  registerSeekToTime: (seek: ((timestamp: number) => void) | null) => void;
 }
 
 const NavigationContext = createContext<NavigationContextType | undefined>(
@@ -87,6 +93,16 @@ export default function RepairScreen({
 
   const os = capture?.task ? capture.task.os : "none";
   const [focusViewIndex, setFocusViewIndex] = useState<number>(-1);
+
+  // Held in a ref rather than state: registering a seek function must not
+  // re-render, and the jump effect only ever reads the current one.
+  const seekToTimeRef = useRef<((timestamp: number) => void) | null>(null);
+  const registerSeekToTime = useCallback(
+    (seek: ((timestamp: number) => void) | null) => {
+      seekToTimeRef.current = seek;
+    },
+    [],
+  );
 
   // UI-level guard for keyboard/arrow navigation so users cannot leave a screen
   // with incomplete required template fields. Matches validateGestureDescription
@@ -229,6 +245,11 @@ export default function RepairScreen({
     if (targetIndex >= 0) {
       appliedJumpNonceRef.current = jumpTarget.nonce;
       setFocusViewIndex(targetIndex);
+      // Move the recording to the same screen, matching what clicking the
+      // filmstrip already does. Without this the playhead stays where it was,
+      // and `c` would capture a frame from an unrelated part of the video —
+      // which is exactly what the feedback often asks the worker to do.
+      seekToTimeRef.current?.(screens[targetIndex].timestamp);
     }
   }, [jumpTarget, screens]);
 
@@ -240,6 +261,7 @@ export default function RepairScreen({
         handleDeleteScreen,
         focusViewIndex,
         setFocusViewIndex,
+        registerSeekToTime,
       }}
     >
       {(os.toLowerCase() as Platform) === Platform.ANDROID ? (

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/index.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/index.ts
@@ -2,3 +2,4 @@ export * from "./ios-video-operations";
 export * from "./configs";
 export * from "./android-gesture-translate";
 export * from "./gesture-description-template";
+export * from "./use-form-field-key-press-guard";

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/use-form-field-key-press-guard.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/use-form-field-key-press-guard.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Remembers, per key, whether the keydown that started the current press landed
+ * inside a form field.
+ *
+ * `keyup`-bound hotkeys cannot trust the release event's target. If the field
+ * being typed into unmounts between keydown and keyup — which happens whenever
+ * a form write moves the focused screen — the release arrives with `<body>` as
+ * its target and is indistinguishable from a bare workspace keypress. The
+ * keydown is the only trustworthy signal of intent, so it gets recorded there.
+ *
+ * @returns Predicate answering whether the in-flight press of `key` began as
+ * text entry.
+ */
+export function useFormFieldKeyPressGuard() {
+  const keysStartedInFormFieldRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const isFormField = (target: EventTarget | null) =>
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      (target instanceof HTMLElement && target.isContentEditable);
+
+    // Capture phase, so the flag is recorded before any hotkey handler reads it
+    // and before React commits the update that may unmount the field.
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      if (isFormField(event.target)) {
+        keysStartedInFormFieldRef.current.add(key);
+        return;
+      }
+      // Cleared on the next keydown rather than on keyup: a key's keydown
+      // always precedes its keyup, so this is enough to keep flags fresh, and
+      // it avoids racing the keyup listeners that need to read the flag.
+      keysStartedInFormFieldRef.current.delete(key);
+    };
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, []);
+
+  return useCallback(
+    (key: string) => keysStartedInFormFieldRef.current.has(key.toLowerCase()),
+    [],
+  );
+}

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -97,6 +97,10 @@ export default function Page() {
     useState<RepairScreenJumpTarget | null>(null);
   const [redactScreenJumpTarget, setRedactScreenJumpTarget] =
     useState<RedactScreenJumpTarget | null>(null);
+  // Identifies each jump request so the editors can apply one exactly once.
+  // A counter rather than a timestamp: two clicks inside the same millisecond
+  // would otherwise share a nonce, and the second jump would be dropped.
+  const jumpNonceRef = useRef(0);
   const [checklistLayoutMode, setChecklistLayoutMode] =
     useState<ChecklistLayoutMode>(() => {
       if (typeof window === "undefined") {
@@ -727,9 +731,10 @@ export default function Page() {
       return;
     }
 
+    jumpNonceRef.current += 1;
     const nextTarget = {
       screenId,
-      nonce: Date.now(),
+      nonce: jumpNonceRef.current,
     };
 
     if (stepIndex === TraceSteps.Redact) {


### PR DESCRIPTION
## The bug

A worker fixing annotate feedback reported that focus jumped to a different screen **on every keystroke**, and supplied a screen recording. Two distinct defects, one causing the other.

### A. The feedback jump was never consumed

`repair-screen.tsx` moves focus when a feedback checklist chip is clicked, keyed on `[jumpTarget, screens]`. `jumpTarget` is set on click and never cleared — the `nonce` existed but nothing recorded that a jump had been applied.

The non-obvious half is why `screens` counted as changed. Typing writes only `gestures`, but `react-hook-form` broadcasts `values: cloneObject(_formValues)` on **every** `setValue` (`index.esm.mjs:1651-1654`) — a deep clone. So `useWatch` hands back a fresh `screens` array on every keystroke, the effect re-fires, and focus is yanked back to the chip's screen.

```
keystroke -> setValue("gestures") -> RHF deep-clones form values
          -> useWatch gives RepairScreen a NEW screens array
          -> [jumpTarget, screens] looks changed -> setFocusViewIndex()
```

Fixed with a nonce guard. `screens` stays in the deps so a jump requested before the screens load still lands.

### B. A keyup hotkey fired after its input unmounted

The focus change unmounts the annotation editor (`key={focusedScreen.id}`), destroying the focused `<input>` mid-keypress. Workspace hotkeys are gated on the event target being a form field, but `c` is bound with `{ keyup: true }`: its keydown was suppressed while the input existed, then its **keyup arrived with `<body>` as the target** and fired `handleCaptureFrame()`.

In the recording this captured a phantom duplicate screen at the playhead, changing the trace's screen count and renumbering screens underneath the evaluator's feedback. Added `useFormFieldKeyPressGuard`, which records on keydown whether a press began as text entry.

## Also in this PR

- **The playhead now follows a chip jump.** A filmstrip click already sets focus *and* seeks; a chip only set focus. Beyond the inconsistency, `c` captures at the playhead rather than at the focused screen, so a worker acting on "please include the missing screen" could insert a frame from an unrelated part of the video. Seeks with `syncFocus: false`, since the default re-derives focus from the nearest timestamp and can bounce onto a neighbouring screen. Scoped to the jump — `Tab`/arrows still leave the playhead alone.
- **That seek waits for the video bootstrap to finish.** Bootstrap seeks the live `<video>` element while extracting frames (the warmup grab alone moves it to 0.1s), and each seek fires `seeked`, which the scrub hook writes back over `currentTime`. A seek placed earlier landed and was immediately dragged to the start, and never self-corrected because a jump applies exactly once. Reachable on any re-entry to the annotate step with a jump still armed. `useIosVideoBootstrap` now reports readiness and the seek waits for it. Both the defect and an earlier wrong fix (gating on `videoDuration > 0`, which is set too early) were caught by red-teaming plus QA.
- **`nonce` is now a monotonic counter** rather than `Date.now()`. The guards make it load-bearing: two clicks in the same millisecond would have shared a value and dropped the second jump.

`redact-screen.tsx` gets the same guard defensively. It does not currently reach the bug because it reads `screens` via `getValues`, which returns the live reference rather than a clone — an accident worth not depending on.

## Reproducing

Needs a capture whose `annotateFeedback` contains screen-scoped lines (`Screen 10: …`), so the checklist renders jumpable chips. Stay on the **Annotate** step.

1. Click a chip — focus moves to that screen. *(This arms the bug; everything after is broken until reload.)*
2. Click any other screen in the filmstrip. Inserting a screen is **not** required.
3. Pick a gesture type and type one character into the first template slot.

**Before:** focus snaps back to the chip's screen, and every later keystroke repeats it. Typing `c` also captures a phantom screen.
**After:** the character lands and focus stays put.

## Verification

- `npm run type-check` and `eslint` clean.
- Guard logic exercised against real `react-hook-form` broadcasts: chip click plus 10 keystrokes goes from 11 focus changes to 1, while a new chip click, a repeat click of the same chip, and the load-order retry each still jump exactly once.
- Manual QA by @carlguo2: original repro fixed; repros A/B/C re-run with no regressions; chip jump moves the playhead; leaving to redact and returning restores the playhead once the video loads.

## Known gaps, deliberately not in scope

- `focusViewIndex` is still a positional index, so inserting a screen earlier in the trace silently moves focus to a neighbour. This is the residual issue most likely to affect workers, since the feedback itself often asks them to add a missing screen.
- Filmstrip clicks still seek with `syncFocus: true`, so a click can bounce focus to a neighbour when two screens share a near-identical timestamp.
- Only `c` is guarded among the workspace hotkeys. Fixing A removed the trigger, so the rest are latent rather than live.
- The seek is plumbed by handing a callback up through `NavigationContext`, plus a pending-seek ref and a readiness flag. It matches the existing ref back-channels in that file but points the wrong way. The underlying problem is that playhead position has no owner — it lives in the DOM element, mirrored in `currentTime`, with bootstrap, scrubbing, hotkeys and jumps all racing to write it. The intended follow-up is one owner for selected-screen-id plus playhead, with navigation intents tagged by source, which retires this plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
