### PR TITLE
chore: drop departed lab member from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
 *   @carlguo2
-*   @Nobody912


### PR DESCRIPTION
`@Nobody912` has left the lab, so an auto-requested review from that account can never be satisfied.

## The subtlety

```
*   @carlguo2
*   @Nobody912
```

CODEOWNERS is **last-match-wins, not additive**. Both entries match `*`, so the second line made `@Nobody912` the sole owner of every path and `@carlguo2` no owner at all. Removing that line promotes `@carlguo2` to owner.

## What is deliberately unchanged

Review requirements stay as they are, so the rule keeps working once someone else joins:

| branch | required approvals | code owner review |
| --- | --- | --- |
| `odim-dev-env` | 1 | not required |
| `main` | 1 | required |

Consequence worth stating: with a single owner who is also the PR author, GitHub still won't count a self-approval, so PRs will need the admin override until a second person is added. That is the intended steady state, not a misconfiguration.

`main` keeps the old file until the next `odim-dev-env` → `main` merge carries this across; nothing needs to commit directly to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)