### PR TITLE
Annotate workspace: truthful preview, id-based selection, validation that names screens

### DIFF
--- a/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/components/filmstrip.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/components/filmstrip.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { CircleAlert } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FrameData, Redaction } from "../../types";
+import { countUnlabelledRedactions } from "../../../util";
 
 export function Filmstrip({
   screens,
@@ -25,6 +26,9 @@ export function Filmstrip({
           screen={screen}
           redactions={redactions[screen.id] ?? []}
           isSelected={focusViewIndex === index}
+          // Same predicate the step gate uses, so the screens ringed here are
+          // exactly the screens its error names.
+          hasError={countUnlabelledRedactions(redactions[screen.id]) > 0}
           onClick={() => setFocusViewIndex(index)}
         ></FilmstripItem>
       ))}

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/android/repair-screen-android.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/android/repair-screen-android.tsx
@@ -30,7 +30,7 @@ export function RepairScreenAndroid({
   draftFetchResult: DraftFetchResults;
 }) {
   const { setValue } = useFormContext<TraceFormData>();
-  const { focusViewIndex } = useNavigation();
+  const { focusedScreenId, focusedIndex } = useNavigation();
   const [watchScreens, watchVHs, watchGestures, watchRedactions] = useWatch({
     name: ["screens", "vhs", "gestures", "redactions"],
   });
@@ -40,6 +40,8 @@ export function RepairScreenAndroid({
   const originalGestures = useRef<{ [key: string]: ScreenGesture }>({});
   const originalRedactions = useRef<{ [key: string]: Redaction[] }>({});
   const currScreens = watchScreens as FrameData[];
+  const focusedAndroidScreen =
+    currScreens.find((screen) => screen.id === focusedScreenId) ?? null;
   const currVHs = watchVHs as { [key: string]: any };
   const currGestures = watchGestures as { [key: string]: ScreenGesture };
   const currRedactions = watchRedactions as { [key: string]: Redaction[] };
@@ -197,12 +199,12 @@ export function RepairScreenAndroid({
                   setShowBoxes={setShowBoxes}
                 />
               </div>
-              {focusViewIndex > -1 && focusViewIndex < currScreens.length ? (
+              {focusedAndroidScreen ? (
                 <FocusViewAndroid
-                  key={focusViewIndex}
-                  vh={currVHs[currScreens[focusViewIndex].id]}
-                  screen={currScreens[focusViewIndex]}
-                  isLastScreen={focusViewIndex === currScreens.length - 1}
+                  key={focusedAndroidScreen.id}
+                  vh={currVHs[focusedAndroidScreen.id]}
+                  screen={focusedAndroidScreen}
+                  isLastScreen={focusedIndex === currScreens.length - 1}
                   showBoxes={showBoxes}
                 />
               ) : (

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
@@ -141,7 +141,6 @@ function FilmstripItem({
   return (
     <motion.li
       className="cursor-pointer min-w-fit h-full max-w-full"
-      data-index={index}
       data-screen-id={screen.id}
       variants={card}
       initial="initial"

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
@@ -31,12 +31,12 @@ export function Filmstrip({
   os: Platform;
   handleSetTime: (t: number) => void;
 }) {
-  const { focusViewIndex, setFocusViewIndex, handleDeleteScreen } =
+  const { focusedScreenId, setFocusedScreenId, handleDeleteScreen } =
     useNavigation();
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (focusViewIndex < 0) {
+    if (focusedScreenId === null) {
       return;
     }
 
@@ -46,8 +46,10 @@ export function Filmstrip({
         return;
       }
 
+      // Queried by id, not position: an insert shifts every later index, so a
+      // positional selector can scroll to the wrong thumbnail.
       const selectedItem = container.querySelector<HTMLElement>(
-        `[data-index="${focusViewIndex}"]`,
+        `[data-screen-id="${focusedScreenId}"]`,
       );
       if (!selectedItem) {
         return;
@@ -71,7 +73,7 @@ export function Filmstrip({
     return () => {
       cancelAnimationFrame(frame);
     };
-  }, [focusViewIndex, screens.length]);
+  }, [focusedScreenId, screens.length]);
 
   return (
     <div ref={containerRef} className="h-full overflow-x-auto">
@@ -87,7 +89,7 @@ export function Filmstrip({
                 gesture={gestures[screen.id]}
                 redactions={redactions[screen.id] ?? []}
                 os={os}
-                isSelected={focusViewIndex === index}
+                isSelected={focusedScreenId === screen.id}
                 hasError={
                   isLast
                     ? false
@@ -95,7 +97,7 @@ export function Filmstrip({
                       gestures[screen.id].type === null ||
                       !validateGestureDescription(gestures[screen.id])
                 }
-                onClick={() => setFocusViewIndex(index)}
+                onClick={() => setFocusedScreenId(screen.id)}
                 handleSetTime={handleSetTime}
                 handleDeleteFrame={handleDeleteScreen}
               />
@@ -127,7 +129,7 @@ function FilmstripItem({
   isSelected?: boolean;
   hasError?: boolean;
   handleSetTime: (t: number) => void;
-  handleDeleteFrame: (index: number) => void;
+  handleDeleteFrame: (screenId: string) => void;
   onClick?: () => void;
 }) {
   const hasGestureCoordinates =
@@ -140,6 +142,7 @@ function FilmstripItem({
     <motion.li
       className="cursor-pointer min-w-fit h-full max-w-full"
       data-index={index}
+      data-screen-id={screen.id}
       variants={card}
       initial="initial"
       animate="animate"
@@ -166,7 +169,7 @@ function FilmstripItem({
           onClick={(e) => {
             // Prevent bubbling to parent click handlers that set focus/time
             e.stopPropagation();
-            handleDeleteFrame(index);
+            handleDeleteFrame(screen.id);
           }}
           className="inline-flex self-end items-center cursor-pointer"
           title="Delete snapshot"

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
@@ -15,7 +15,7 @@ import Image from "next/image";
 import { card } from "../util";
 import { spring } from "@/lib/motion";
 import { findGestureOption } from "@/lib/utils/gesture-options";
-import { validateGestureDescription } from "../util";
+import { isScreenAnnotationComplete } from "../util";
 import { useEffect, useRef } from "react";
 
 export function Filmstrip({
@@ -91,11 +91,7 @@ export function Filmstrip({
                 os={os}
                 isSelected={focusedScreenId === screen.id}
                 hasError={
-                  isLast
-                    ? false
-                    : !gestures[screen.id] ||
-                      gestures[screen.id].type === null ||
-                      !validateGestureDescription(gestures[screen.id])
+                  isLast ? false : !isScreenAnnotationComplete(gestures[screen.id])
                 }
                 onClick={() => setFocusedScreenId(screen.id)}
                 handleSetTime={handleSetTime}

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -35,8 +35,12 @@ export function RepairScreenIOS({
   os: Platform;
   draftFetchResult: DraftFetchResults;
 }) {
-  const { focusViewIndex, setFocusViewIndex, registerSeekToTime } =
-    useNavigation();
+  const {
+    focusedScreenId,
+    setFocusedScreenId,
+    focusedIndex,
+    registerSeekToTime,
+  } = useNavigation();
   const { setValue } = useFormContext<TraceFormData>();
   const { register: registerScreenUrl } = useScreenBlobRegistry();
   const [watchScreens, watchGestures, watchRedactions] = useWatch({
@@ -47,17 +51,15 @@ export function RepairScreenIOS({
   const gestures = watchGestures as { [key: string]: ScreenGesture };
   const redactions = watchRedactions as { [key: string]: Redaction[] };
   const focusedScreen =
-    focusViewIndex > -1 && focusViewIndex < screens.length
-      ? screens[focusViewIndex]
-      : null;
+    screens.find((screen) => screen.id === focusedScreenId) ?? null;
   const captureMarkers = useMemo(
     () =>
-      screens.map((screen, index) => ({
+      screens.map((screen) => ({
         id: screen.id,
         timestamp: screen.timestamp,
-        isFocused: focusViewIndex === index,
+        isFocused: screen.id === focusedScreenId,
       })),
-    [focusViewIndex, screens],
+    [focusedScreenId, screens],
   );
 
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -86,8 +88,8 @@ export function RepairScreenIOS({
 
   const { syncFocusToTimestamp } = useIosScreenFocusSync({
     screens,
-    focusViewIndex,
-    setFocusViewIndex,
+    focusedScreenId,
+    setFocusedScreenId,
   });
 
   // Bootstrap: load video, populate screens, expose duration + thumbnails.
@@ -117,7 +119,7 @@ export function RepairScreenIOS({
   } = useIosVideoPlayback({
     videoRef,
     videoDuration,
-    focusViewIndex,
+    focusedScreenId,
     onLivePhotoStart,
   });
 
@@ -232,10 +234,10 @@ export function RepairScreenIOS({
     "r",
     (e) => {
       e.preventDefault();
-      if (focusViewIndex < 0 || focusViewIndex >= screens.length) return;
-      handleLivePhoto(screens[focusViewIndex].timestamp);
+      if (!focusedScreen) return;
+      handleLivePhoto(focusedScreen.timestamp);
     },
-    [focusViewIndex, screens, handleLivePhoto],
+    [focusedScreen, handleLivePhoto],
   );
 
   useHotkeys(
@@ -310,7 +312,7 @@ export function RepairScreenIOS({
               <RepairFocusPanelIOS
                 taskDescription={taskDescription}
                 focusedScreen={focusedScreen}
-                isLastScreen={focusViewIndex === screens.length - 1}
+                isLastScreen={focusedIndex === screens.length - 1}
                 isLivePhotoActive={isLivePhotoActive}
                 onLivePhoto={handleLivePhoto}
               />

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -217,7 +217,12 @@ export function RepairScreenIOS({
       "screens",
       [...screens, f].sort((a, b) => a.timestamp - b.timestamp),
     );
-  }, [currentTime, registerScreenUrl, screens, setValue]);
+    // Focus what was just captured. Every screen but the last needs a gesture,
+    // so capturing is always followed by annotating it — and leaving focus
+    // behind meant hunting for the new frame in the filmstrip first. No seek is
+    // needed: the playhead is already at this screen's timestamp.
+    setFocusedScreenId(f.id);
+  }, [currentTime, registerScreenUrl, screens, setFocusedScreenId, setValue]);
 
   // Workspace keybinds
   useHotkeys("space", async (e) => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-screen-focus-sync.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-screen-focus-sync.ts
@@ -4,14 +4,14 @@ import { findNearestScreenIndex } from "./ios-helpers";
 
 interface UseIosScreenFocusSyncArgs {
   screens: FrameData[];
-  focusViewIndex: number;
-  setFocusViewIndex: (index: number) => void;
+  focusedScreenId: string | null;
+  setFocusedScreenId: (screenId: string | null) => void;
 }
 
 export function useIosScreenFocusSync({
   screens,
-  focusViewIndex,
-  setFocusViewIndex,
+  focusedScreenId,
+  setFocusedScreenId,
 }: UseIosScreenFocusSyncArgs) {
   const getNearestScreenIndex = useCallback(
     (time: number) => findNearestScreenIndex(screens, time),
@@ -21,11 +21,15 @@ export function useIosScreenFocusSync({
   const syncFocusToTimestamp = useCallback(
     (time: number) => {
       const nextIndex = getNearestScreenIndex(time);
-      if (nextIndex >= 0 && nextIndex !== focusViewIndex) {
-        setFocusViewIndex(nextIndex);
+      if (nextIndex < 0) {
+        return;
+      }
+      const nextScreenId = screens[nextIndex].id;
+      if (nextScreenId !== focusedScreenId) {
+        setFocusedScreenId(nextScreenId);
       }
     },
-    [focusViewIndex, getNearestScreenIndex, setFocusViewIndex],
+    [focusedScreenId, getNearestScreenIndex, screens, setFocusedScreenId],
   );
 
   return { getNearestScreenIndex, syncFocusToTimestamp };

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -178,12 +178,21 @@ export function useIosScrubPreview({
       requestAnimationFrame(() => {
         isSeekInFlightRef.current = false;
         pendingSeekTimeRef.current = null;
-        const scrubTargetTime = scrubPreviewTimeRef.current;
-        if (
+
+        // Has the playhead come to rest? The drag is over and nothing newer is
+        // queued, so wherever the element landed is the final position.
+        //
+        // Deliberately not an exact comparison against the requested time.
+        // Browsers snap `currentTime` to the nearest decodable frame, so the
+        // landed value usually differs by more than a millisecond — gating on an
+        // exact match left the coarse thumbnail up at random, which is why the
+        // preview and the real frame sometimes still disagreed after mouseup.
+        const hasPlayheadSettled =
           !isScrubPreviewActiveRef.current &&
-          scrubTargetTime !== null &&
-          Math.abs(video.currentTime - scrubTargetTime) <= 0.001
-        ) {
+          scrubQueuedSeekTimeRef.current === null &&
+          scrubSeekTimeoutRef.current === null;
+
+        if (hasPlayheadSettled && scrubPreviewTimeRef.current !== null) {
           scrubPreviewTimeRef.current = null;
           setScrubPreviewTime(null);
         }
@@ -197,16 +206,13 @@ export function useIosScrubPreview({
           updateCurrentTime(video.currentTime);
         }
 
-        // Reveal the real frame now that the seek has landed. The overlay is
-        // only meant to cover seek latency, but a preview thumbnail is a
-        // nearest-neighbour pick off a coarse grid — roughly 1.2s apart on a
-        // long recording, so up to ~0.6s from the playhead. Leaving it up means
-        // the worker aims with an image that can be half a second stale while
-        // `c` captures the accurate frame underneath it.
-        if (
-          !isScrubPreviewActiveRef.current &&
-          scrubPreviewTimeRef.current === null
-        ) {
+        // Reveal the real frame. The overlay is only meant to cover seek
+        // latency, but a preview thumbnail is a nearest-neighbour pick off a
+        // coarse grid — roughly 1.2s apart on a long recording, so up to ~0.6s
+        // from the playhead. Leaving it up means the worker aims with an image
+        // that can be half a second stale while `c` captures the accurate frame
+        // underneath it.
+        if (hasPlayheadSettled) {
           setPausedPreviewTime(null);
         }
       });

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -196,6 +196,19 @@ export function useIosScrubPreview({
           lastCommittedVideoTimeRef.current = video.currentTime;
           updateCurrentTime(video.currentTime);
         }
+
+        // Reveal the real frame now that the seek has landed. The overlay is
+        // only meant to cover seek latency, but a preview thumbnail is a
+        // nearest-neighbour pick off a coarse grid — roughly 1.2s apart on a
+        // long recording, so up to ~0.6s from the playhead. Leaving it up means
+        // the worker aims with an image that can be half a second stale while
+        // `c` captures the accurate frame underneath it.
+        if (
+          !isScrubPreviewActiveRef.current &&
+          scrubPreviewTimeRef.current === null
+        ) {
+          setPausedPreviewTime(null);
+        }
       });
     };
     video.addEventListener("seeked", syncSeekTime);

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-playback.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-playback.ts
@@ -3,14 +3,14 @@ import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 interface UseIosVideoPlaybackArgs {
   videoRef: RefObject<HTMLVideoElement | null>;
   videoDuration: number;
-  focusViewIndex: number;
+  focusedScreenId: string | null;
   onLivePhotoStart?: () => void;
 }
 
 export function useIosVideoPlayback({
   videoRef,
   videoDuration,
-  focusViewIndex,
+  focusedScreenId,
   onLivePhotoStart,
 }: UseIosVideoPlaybackArgs) {
   const rafRef = useRef<number>(0);
@@ -53,7 +53,7 @@ export function useIosVideoPlayback({
   useEffect(() => {
     livePhotoEndRef.current = null;
     setIsLivePhotoActive(false);
-  }, [focusViewIndex]);
+  }, [focusedScreenId]);
 
   const handlePlayPause = useCallback(async () => {
     const video = videoRef.current;

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/video-preview-overlay.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/video-preview-overlay.tsx
@@ -62,6 +62,21 @@ export function VideoPreviewOverlay({
           )}
         />
       ) : null}
+      {/*
+        Preview frames come from a coarse thumbnail grid — roughly a second apart
+        on a long recording — so what is showing here can sit up to half a second
+        from the playhead. Labelling it means the correction when the real frame
+        arrives reads as the picture sharpening rather than the tool changing its
+        mind, and it marks the moments when `c` would capture something other
+        than what is on screen.
+      */}
+      {hasPreviewOverlay ? (
+        <div className="pointer-events-none absolute left-1/2 top-3 z-30 -translate-x-1/2">
+          <span className="inline-flex items-center rounded-md border border-black/15 bg-black/55 px-2 py-1 text-[11px] font-semibold tracking-wide text-white shadow-sm dark:border-white/25 dark:bg-white/90 dark:text-black">
+            Preview
+          </span>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
@@ -127,8 +127,8 @@ export default function RepairScreen({
   );
 
   // Navigation is deliberately unguarded. Gesture completeness is enforced
-  // where it can actually hold — the step's Next button validates every screen
-  // against ScreenGestureSchema and reports each failure (page.tsx). Blocking
+  // where it can actually hold — the step gates in page.tsx check every screen
+  // and name each one that needs work. Blocking
   // Tab/arrows only trapped keyboard users: it was silent, one-directional
   // (Previous was always free), and bypassed by clicking a filmstrip item or a
   // feedback chip, so it enforced nothing while making the keyboard feel broken

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
@@ -26,6 +26,12 @@ export interface RepairScreenJumpTarget {
   screenId: string;
 }
 
+/**
+ * Stable fallback for the watched screens list. A fresh `[]` literal would
+ * change identity every render and defeat every dependency array that reads it.
+ */
+const EMPTY_SCREENS: FrameData[] = [];
+
 interface NavigationContextType {
   handleNext: () => void;
   handlePrevious: () => void;
@@ -93,14 +99,12 @@ export default function RepairScreen({
   jumpTarget?: RepairScreenJumpTarget | null;
 }) {
   const { getValues, setValue } = useFormContext<TraceFormData>();
-  const [watchScreens, watchGestures] = useWatch({
-    name: ["screens", "gestures"],
-  });
-  const screens = watchScreens as FrameData[];
-  const gestures = useMemo(
-    () => (watchGestures ?? {}) as { [key: string]: ScreenGesture },
-    [watchGestures],
-  );
+  // Only `screens` is watched. Dropping the `gestures` subscription keeps this
+  // component from re-rendering on every keystroke in the annotation editor —
+  // react-hook-form hands out a deep clone of the form on each write, which is
+  // what made the jump effect re-fire per keystroke in the first place.
+  const screens = (useWatch({ name: "screens" }) ??
+    EMPTY_SCREENS) as FrameData[];
 
   const os = capture?.task ? capture.task.os : "none";
   const [focusedScreenId, setFocusedScreenId] = useState<string | null>(null);
@@ -122,23 +126,14 @@ export default function RepairScreen({
     [],
   );
 
-  // UI-level guard for keyboard/arrow navigation so users cannot leave a screen
-  // with incomplete required template fields. Matches validateGestureDescription
-  // used by filmstrip and form schema.
-  const canAdvanceFromCurrentScreen = useCallback(() => {
-    if (focusedIndex < 0 || focusedIndex >= screens.length) {
-      return true;
-    }
-    // Last screen does not require a gesture.
-    if (focusedIndex === screens.length - 1) {
-      return true;
-    }
-    const currentScreen = screens[focusedIndex];
-    const currentGesture = gestures[currentScreen.id];
-    return validateGestureDescription(
-      currentGesture ?? { type: null, description: "" },
-    );
-  }, [focusedIndex, gestures, screens]);
+  // Navigation is deliberately unguarded. Gesture completeness is enforced
+  // where it can actually hold — the step's Next button validates every screen
+  // against ScreenGestureSchema and reports each failure (page.tsx). Blocking
+  // Tab/arrows only trapped keyboard users: it was silent, one-directional
+  // (Previous was always free), and bypassed by clicking a filmstrip item or a
+  // feedback chip, so it enforced nothing while making the keyboard feel broken
+  // — you could not even reach a newly captured screen without first filling in
+  // every incomplete screen ahead of it.
 
   // handle focusing on previous screen in the filmstrip list
   const handlePrevious = useCallback(() => {
@@ -158,12 +153,9 @@ export default function RepairScreen({
     if (screens.length === 0) {
       return;
     }
-    if (!canAdvanceFromCurrentScreen()) {
-      return;
-    }
     const wrappedIndex = (focusedIndex + 1) % screens.length;
     setFocusedScreenId(screens[wrappedIndex].id);
-  }, [canAdvanceFromCurrentScreen, focusedIndex, screens]);
+  }, [focusedIndex, screens]);
 
   const handleDeleteScreen = useCallback(
     (screenId: string) => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
@@ -29,9 +29,20 @@ export interface RepairScreenJumpTarget {
 interface NavigationContextType {
   handleNext: () => void;
   handlePrevious: () => void;
-  handleDeleteScreen: (index: number) => void;
-  focusViewIndex: number;
-  setFocusViewIndex: (index: number) => void;
+  handleDeleteScreen: (screenId: string) => void;
+  /**
+   * The focused screen, identified by id. Authoritative — inserting or deleting
+   * a screen shifts positions, so an index cannot survive an edit to the trace.
+   */
+  focusedScreenId: string | null;
+  setFocusedScreenId: (screenId: string | null) => void;
+  /**
+   * Position of the focused screen in the sorted list, derived from
+   * `focusedScreenId`. Provided here so ordering questions ("is this the last
+   * screen?", "what is next?") have one answer rather than one per consumer.
+   * `-1` when nothing is focused or the focused screen no longer exists.
+   */
+  focusedIndex: number;
   /**
    * Lets a platform with a scrubbable recording hand up a seek function, so an
    * explicit jump to a screen can move the playhead with it. Pass `null` to
@@ -92,7 +103,14 @@ export default function RepairScreen({
   );
 
   const os = capture?.task ? capture.task.os : "none";
-  const [focusViewIndex, setFocusViewIndex] = useState<number>(-1);
+  const [focusedScreenId, setFocusedScreenId] = useState<string | null>(null);
+  const focusedIndex = useMemo(
+    () =>
+      focusedScreenId === null
+        ? -1
+        : screens.findIndex((screen) => screen.id === focusedScreenId),
+    [focusedScreenId, screens],
+  );
 
   // Held in a ref rather than state: registering a seek function must not
   // re-render, and the jump effect only ever reads the current one.
@@ -108,19 +126,19 @@ export default function RepairScreen({
   // with incomplete required template fields. Matches validateGestureDescription
   // used by filmstrip and form schema.
   const canAdvanceFromCurrentScreen = useCallback(() => {
-    if (focusViewIndex < 0 || focusViewIndex >= screens.length) {
+    if (focusedIndex < 0 || focusedIndex >= screens.length) {
       return true;
     }
     // Last screen does not require a gesture.
-    if (focusViewIndex === screens.length - 1) {
+    if (focusedIndex === screens.length - 1) {
       return true;
     }
-    const currentScreen = screens[focusViewIndex];
+    const currentScreen = screens[focusedIndex];
     const currentGesture = gestures[currentScreen.id];
     return validateGestureDescription(
       currentGesture ?? { type: null, description: "" },
     );
-  }, [focusViewIndex, gestures, screens]);
+  }, [focusedIndex, gestures, screens]);
 
   // handle focusing on previous screen in the filmstrip list
   const handlePrevious = useCallback(() => {
@@ -128,12 +146,12 @@ export default function RepairScreen({
       return;
     }
     // javascript be stupid, negative modulo isn't a thing here
-    let wrappedIndex = (focusViewIndex - 1) % screens.length;
+    let wrappedIndex = (focusedIndex - 1) % screens.length;
     if (wrappedIndex < 0) {
       wrappedIndex = screens.length - 1;
     }
-    setFocusViewIndex(wrappedIndex);
-  }, [focusViewIndex, screens.length]);
+    setFocusedScreenId(screens[wrappedIndex].id);
+  }, [focusedIndex, screens]);
 
   // handle focusing on next screen in the filmstrip list
   const handleNext = useCallback(() => {
@@ -143,14 +161,17 @@ export default function RepairScreen({
     if (!canAdvanceFromCurrentScreen()) {
       return;
     }
-    const wrappedIndex = (focusViewIndex + 1) % screens.length;
-    setFocusViewIndex(wrappedIndex);
-  }, [canAdvanceFromCurrentScreen, focusViewIndex, screens.length]);
+    const wrappedIndex = (focusedIndex + 1) % screens.length;
+    setFocusedScreenId(screens[wrappedIndex].id);
+  }, [canAdvanceFromCurrentScreen, focusedIndex, screens]);
 
   const handleDeleteScreen = useCallback(
-    (index: number) => {
+    (screenId: string) => {
       const currentScreens = getValues("screens");
-      if (index < 0 || index >= currentScreens.length) {
+      const index = currentScreens.findIndex(
+        (screen) => screen.id === screenId,
+      );
+      if (index < 0) {
         return;
       }
 
@@ -176,7 +197,7 @@ export default function RepairScreen({
       setValue("gestures", nextGestures);
       setValue("redactions", nextRedactions);
       setValue("vhs", nextVHs);
-      setFocusViewIndex(-1);
+      setFocusedScreenId(null);
     },
     [getValues, setValue],
   );
@@ -212,15 +233,18 @@ export default function RepairScreen({
     "backspace",
     (event) => {
       event.preventDefault();
-      handleDeleteScreen(focusViewIndex);
+      if (focusedScreenId === null) {
+        return;
+      }
+      handleDeleteScreen(focusedScreenId);
     },
     {
-      enabled: focusViewIndex >= 0,
+      enabled: focusedScreenId !== null,
       enableOnFormTags: false,
       enableOnContentEditable: false,
       preventDefault: true,
     },
-    [focusViewIndex, handleDeleteScreen],
+    [focusedScreenId, handleDeleteScreen],
   );
 
   // A checklist jump must apply exactly once per click. `screens` stays in the
@@ -244,7 +268,7 @@ export default function RepairScreen({
     );
     if (targetIndex >= 0) {
       appliedJumpNonceRef.current = jumpTarget.nonce;
-      setFocusViewIndex(targetIndex);
+      setFocusedScreenId(jumpTarget.screenId);
       // Move the recording to the same screen, matching what clicking the
       // filmstrip already does. Without this the playhead stays where it was,
       // and `c` would capture a frame from an unrelated part of the video —
@@ -259,8 +283,9 @@ export default function RepairScreen({
         handleNext,
         handlePrevious,
         handleDeleteScreen,
-        focusViewIndex,
-        setFocusViewIndex,
+        focusedScreenId,
+        setFocusedScreenId,
+        focusedIndex,
         registerSeekToTime,
       }}
     >

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/gesture-description-template.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/gesture-description-template.ts
@@ -311,28 +311,53 @@ export function validateGestureDescription(
   });
 }
 
+/** The reason a screen's annotation is not finished yet. */
+export type ScreenAnnotationIssue =
+  | "missing-gesture"
+  | "missing-type"
+  | "missing-marker"
+  | "incomplete-drag"
+  | "incomplete-description";
+
+/** What the worker has to do about each issue, phrased as an instruction. */
+export const SCREEN_ANNOTATION_ISSUE_ACTIONS: Record<
+  ScreenAnnotationIssue,
+  string
+> = {
+  "missing-gesture": "add a gesture",
+  "missing-type": "choose a gesture type",
+  "missing-marker": "place the gesture on the screen",
+  "incomplete-drag": "add the drag end point",
+  "incomplete-description": "finish the description",
+};
+
+type GestureCompletenessFields = Pick<
+  ScreenGesture,
+  "type" | "description" | "x" | "y" | "scrollDeltaX" | "scrollDeltaY"
+>;
+
 /**
- * Whether a screen's annotation is finished: a gesture exists, it is placed
- * somewhere on the screen, and its description satisfies the template.
+ * Why a screen's annotation is unfinished, or `null` when it is done.
  *
  * Single source of truth for "is this screen done", shared by the filmstrip's
- * error ring and the step's Next gate so the two cannot disagree — previously
- * the ring ignored marker placement while the gate required it, so a screen
- * could look complete and still block the step.
+ * error ring and the step's Next gate so the two cannot disagree — the ring used
+ * to ignore marker placement while the gate required it, so a screen could look
+ * finished and still block the step. Returning the reason rather than a boolean
+ * lets the gate say what is wrong instead of only which screens are wrong.
+ *
+ * Checks run most-basic-first so the reported reason is the one the worker
+ * should act on next.
  *
  * @param gesture - The gesture recorded for a screen, if any.
  */
-export function isScreenAnnotationComplete(
-  gesture:
-    | Pick<
-        ScreenGesture,
-        "type" | "description" | "x" | "y" | "scrollDeltaX" | "scrollDeltaY"
-      >
-    | null
-    | undefined,
-): boolean {
+export function getScreenAnnotationIssue(
+  gesture: GestureCompletenessFields | null | undefined,
+): ScreenAnnotationIssue | null {
   if (!gesture) {
-    return false;
+    return "missing-gesture";
+  }
+  if (!gesture.type) {
+    return "missing-type";
   }
   // validateGestureDescription covers type, template slots and drag end-points,
   // but not whether the marker was ever placed.
@@ -342,9 +367,29 @@ export function isScreenAnnotationComplete(
     gesture.y === null ||
     gesture.y === undefined
   ) {
-    return false;
+    return "missing-marker";
   }
-  return validateGestureDescription(gesture);
+  if (
+    normalizeGestureType(gesture.type) === GESTURE_TYPES.DRAG &&
+    !hasCompleteDragPoints(gesture)
+  ) {
+    return "incomplete-drag";
+  }
+  if (!validateGestureDescription(gesture)) {
+    return "incomplete-description";
+  }
+  return null;
+}
+
+/**
+ * Whether a screen's annotation is finished.
+ *
+ * @param gesture - The gesture recorded for a screen, if any.
+ */
+export function isScreenAnnotationComplete(
+  gesture: GestureCompletenessFields | null | undefined,
+): boolean {
+  return getScreenAnnotationIssue(gesture) === null;
 }
 
 export function hasCompleteDragPoints(

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/gesture-description-template.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/gesture-description-template.ts
@@ -311,6 +311,42 @@ export function validateGestureDescription(
   });
 }
 
+/**
+ * Whether a screen's annotation is finished: a gesture exists, it is placed
+ * somewhere on the screen, and its description satisfies the template.
+ *
+ * Single source of truth for "is this screen done", shared by the filmstrip's
+ * error ring and the step's Next gate so the two cannot disagree — previously
+ * the ring ignored marker placement while the gate required it, so a screen
+ * could look complete and still block the step.
+ *
+ * @param gesture - The gesture recorded for a screen, if any.
+ */
+export function isScreenAnnotationComplete(
+  gesture:
+    | Pick<
+        ScreenGesture,
+        "type" | "description" | "x" | "y" | "scrollDeltaX" | "scrollDeltaY"
+      >
+    | null
+    | undefined,
+): boolean {
+  if (!gesture) {
+    return false;
+  }
+  // validateGestureDescription covers type, template slots and drag end-points,
+  // but not whether the marker was ever placed.
+  if (
+    gesture.x === null ||
+    gesture.x === undefined ||
+    gesture.y === null ||
+    gesture.y === undefined
+  ) {
+    return false;
+  }
+  return validateGestureDescription(gesture);
+}
+
 export function hasCompleteDragPoints(
   gesture: Pick<ScreenGesture, "x" | "y" | "scrollDeltaX" | "scrollDeltaY">,
 ): boolean {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/types.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/types.ts
@@ -85,20 +85,12 @@ export const GestureSchema = z
     },
   );
 
-export const ScreenGestureSchema = z
-  .object({
-    screens: ScreenSchema,
-    gestures: GestureSchema,
-  })
-  .refine(
-    (data) => {
-      // Check all screens except the last one have gestures
-      return data.screens.slice(0, -1).every((screen) => {
-        return data.gestures[screen.id];
-      });
-    },
-    { message: "Each screen except the last one must have a gesture" },
-  );
+// Screen-annotation completeness is not a schema. Layering `.refine` on top of
+// field validation under-reports, because zod skips a refine once the schema
+// beneath it fails, so a screen missing its marker hid every screen missing its
+// gesture entirely. It lives in `getScreenAnnotationIssue`
+// (repair-screen/util/gesture-description-template.ts), which both the
+// filmstrip's error ring and the step gates in page.tsx call.
 
 export const RedactionSchema = z
   .record(

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -78,6 +78,55 @@ const FEEDBACK_STEP_ORDER = [
   TraceSteps.Review,
 ];
 
+type IncompleteScreen = {
+  screenNumber: number;
+  issue: ScreenAnnotationIssue;
+};
+
+/**
+ * Screens whose annotation is unfinished, numbered the way the filmstrip numbers
+ * them. The last screen is the goal state and needs no gesture.
+ *
+ * Scanned per screen rather than parsed with a zod schema. Zod skips a `.refine`
+ * when the schema beneath it failed, and the ways an annotation can be
+ * incomplete sit at different levels — a missing marker fails field validation,
+ * unfilled template slots fail a refine, a screen with no gesture at all fails a
+ * different refine — so any field-level failure hid the rest. Both gates share
+ * this function so they cannot drift apart or under-report.
+ */
+function collectIncompleteScreens(
+  screens: TraceFormData["screens"],
+  gestures: TraceFormData["gestures"],
+): IncompleteScreen[] {
+  return screens
+    .slice(0, -1)
+    .map((screen, index) => ({
+      screenNumber: index + 1,
+      issue: getScreenAnnotationIssue(gestures[screen.id]),
+    }))
+    .filter((entry): entry is IncompleteScreen => entry.issue !== null);
+}
+
+/**
+ * One message saying what each unfinished screen needs. Past four screens the
+ * reasons stop fitting a toast, so it falls back to numbers and points at the
+ * filmstrip, which rings exactly the same set.
+ */
+function describeIncompleteScreens(entries: IncompleteScreen[]): string {
+  const describe = (entry: IncompleteScreen) =>
+    `Screen ${entry.screenNumber}: ${SCREEN_ANNOTATION_ISSUE_ACTIONS[entry.issue]}`;
+
+  if (entries.length === 1) {
+    return `${describe(entries[0])}.`;
+  }
+  if (entries.length <= 4) {
+    return `${entries.length} screens need work — ${entries.map(describe).join("; ")}.`;
+  }
+  return `${entries.length} screens need work: ${entries
+    .map((entry) => entry.screenNumber)
+    .join(", ")}. The filmstrip rings them in yellow.`;
+}
+
 export default function Page() {
   const CHECKLIST_LAYOUT_STORAGE_KEY = "edit-feedback-checklist-layout";
   const params = useParams();
@@ -574,61 +623,14 @@ export default function Page() {
     setIsSubmitting(true);
     // check zod schema validation for each step
     if (stepIndex === TraceSteps.Capture) {
-      // Scanned per screen rather than run through ScreenGestureSchema. Zod skips
-      // a `.refine` when the schema beneath it already failed, and the three ways
-      // an annotation can be incomplete sit at three different levels: a missing
-      // marker fails field validation, an unfilled template fails
-      // GestureSchema's refine, and a screen with no gesture at all fails
-      // ScreenGestureSchema's refine. Any field-level failure therefore silenced
-      // the other two, so a worker fixed one screen, pressed Next, and only then
-      // discovered the next problem.
-      //
-      // isScreenAnnotationComplete is the same predicate the filmstrip uses for
-      // its error ring, so what is flagged here is what is ringed there.
       const { screens: currentScreens, gestures: currentGestures } =
         methods.getValues();
-      // The last screen is the goal state and needs no gesture.
-      const incompleteScreens = currentScreens
-        .slice(0, -1)
-        .map((screen, index) => ({
-          screenNumber: index + 1,
-          issue: getScreenAnnotationIssue(currentGestures[screen.id]),
-        }))
-        .filter(
-          (
-            entry,
-          ): entry is { screenNumber: number; issue: ScreenAnnotationIssue } =>
-            entry.issue !== null,
-        );
-
+      const incompleteScreens = collectIncompleteScreens(
+        currentScreens,
+        currentGestures,
+      );
       if (incompleteScreens.length > 0) {
-        // Say what to do, not just where. Listing bare screen numbers moves the
-        // guesswork rather than removing it. Beyond a handful the per-screen
-        // reasons stop fitting in a toast, so fall back to the numbers and point
-        // at the filmstrip, which rings exactly these screens.
-        const describe = ({
-          screenNumber,
-          issue,
-        }: {
-          screenNumber: number;
-          issue: ScreenAnnotationIssue;
-        }) => `Screen ${screenNumber}: ${SCREEN_ANNOTATION_ISSUE_ACTIONS[issue]}`;
-
-        if (incompleteScreens.length === 1) {
-          toast.error(`${describe(incompleteScreens[0])}.`);
-        } else if (incompleteScreens.length <= 4) {
-          toast.error(
-            `${incompleteScreens.length} screens need work — ${incompleteScreens
-              .map(describe)
-              .join("; ")}.`,
-          );
-        } else {
-          toast.error(
-            `${incompleteScreens.length} screens need work: ${incompleteScreens
-              .map((entry) => entry.screenNumber)
-              .join(", ")}. The filmstrip rings them in yellow.`,
-          );
-        }
+        toast.error(describeIncompleteScreens(incompleteScreens));
         setIsSubmitting(false);
         return;
       }
@@ -647,26 +649,42 @@ export default function Page() {
         return;
       }
     } else if (stepIndex === TraceSteps.Review) {
-      // validate all screen gestures except the last one
-      const allButLastScreenIds = methods
-        .getValues()
-        .screens.slice(0, -1)
-        .map((s) => s.id);
+      const { screens: currentScreens, gestures: currentGestures } =
+        methods.getValues();
+      // Gestures first, with the same predicate and reporting as the capture
+      // step. TraceFormSchema's refines under-report for the reason described on
+      // collectIncompleteScreens, and this is the gate that decides whether a
+      // trace reaches a reviewer — a screen captured after passing the capture
+      // step would otherwise slip through unannotated.
+      const incompleteScreens = collectIncompleteScreens(
+        currentScreens,
+        currentGestures,
+      );
+      if (incompleteScreens.length > 0) {
+        toast.error(describeIncompleteScreens(incompleteScreens));
+        setIsSubmitting(false);
+        return;
+      }
+
+      // Then the rest of the trace — the description above all, which is only
+      // written at this step.
+      const allButLastScreenIds = currentScreens.slice(0, -1).map((s) => s.id);
       const allButLastScreenGestures = Object.fromEntries(
-        Object.entries(methods.getValues().gestures).filter(([id, _]) =>
+        Object.entries(currentGestures).filter(([id]) =>
           allButLastScreenIds.includes(id),
         ),
       );
-      // Validate the entire trace form, especially "description"
       const validation = TraceFormSchema.safeParse({
         ...methods.getValues(),
         gestures: allButLastScreenGestures,
       });
       if (!validation.success) {
-        const errors = validation.error.issues || "Invalid input";
-        errors.forEach((error) => {
-          toast.error(error.message);
-        });
+        console.error(validation.error.issues);
+        // Deduplicated: the schema reports per field, so one cause can surface
+        // several times with the same wording.
+        new Set(validation.error.issues.map((issue) => issue.message)).forEach(
+          (message) => toast.error(message),
+        );
         setIsSubmitting(false);
         return;
       }

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -22,7 +22,11 @@ import {
   TraceFormData,
   TraceFormSchema,
 } from "./components/types";
-import { isScreenAnnotationComplete } from "./components/repair-screen/util";
+import {
+  SCREEN_ANNOTATION_ISSUE_ACTIONS,
+  ScreenAnnotationIssue,
+  getScreenAnnotationIssue,
+} from "./components/repair-screen/util";
 
 import { Button } from "@/components/ui/button";
 import Sheet from "./components/sheet";
@@ -584,21 +588,47 @@ export default function Page() {
       const { screens: currentScreens, gestures: currentGestures } =
         methods.getValues();
       // The last screen is the goal state and needs no gesture.
-      const incompleteScreenNumbers = currentScreens
+      const incompleteScreens = currentScreens
         .slice(0, -1)
-        .map((screen, index) => ({ screen, screenNumber: index + 1 }))
+        .map((screen, index) => ({
+          screenNumber: index + 1,
+          issue: getScreenAnnotationIssue(currentGestures[screen.id]),
+        }))
         .filter(
-          ({ screen }) =>
-            !isScreenAnnotationComplete(currentGestures[screen.id]),
-        )
-        .map(({ screenNumber }) => screenNumber);
-
-      if (incompleteScreenNumbers.length > 0) {
-        toast.error(
-          incompleteScreenNumbers.length === 1
-            ? `Screen ${incompleteScreenNumbers[0]} needs a gesture, a marker on the screen, and a complete description.`
-            : `${incompleteScreenNumbers.length} screens still need work: ${incompleteScreenNumbers.join(", ")}.`,
+          (
+            entry,
+          ): entry is { screenNumber: number; issue: ScreenAnnotationIssue } =>
+            entry.issue !== null,
         );
+
+      if (incompleteScreens.length > 0) {
+        // Say what to do, not just where. Listing bare screen numbers moves the
+        // guesswork rather than removing it. Beyond a handful the per-screen
+        // reasons stop fitting in a toast, so fall back to the numbers and point
+        // at the filmstrip, which rings exactly these screens.
+        const describe = ({
+          screenNumber,
+          issue,
+        }: {
+          screenNumber: number;
+          issue: ScreenAnnotationIssue;
+        }) => `Screen ${screenNumber}: ${SCREEN_ANNOTATION_ISSUE_ACTIONS[issue]}`;
+
+        if (incompleteScreens.length === 1) {
+          toast.error(`${describe(incompleteScreens[0])}.`);
+        } else if (incompleteScreens.length <= 4) {
+          toast.error(
+            `${incompleteScreens.length} screens need work — ${incompleteScreens
+              .map(describe)
+              .join("; ")}.`,
+          );
+        } else {
+          toast.error(
+            `${incompleteScreens.length} screens need work: ${incompleteScreens
+              .map((entry) => entry.screenNumber)
+              .join(", ")}. The filmstrip rings them in yellow.`,
+          );
+        }
         setIsSubmitting(false);
         return;
       }

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -19,10 +19,10 @@ import { toast } from "sonner";
 import {
   DraftTraceFormData,
   RedactionSchema,
-  ScreenGestureSchema,
   TraceFormData,
   TraceFormSchema,
 } from "./components/types";
+import { isScreenAnnotationComplete } from "./components/repair-screen/util";
 
 import { Button } from "@/components/ui/button";
 import Sheet from "./components/sheet";
@@ -570,59 +570,35 @@ export default function Page() {
     setIsSubmitting(true);
     // check zod schema validation for each step
     if (stepIndex === TraceSteps.Capture) {
-      // validate all screen gestures except the last one
-      const allButLastScreenIds = methods
-        .getValues()
-        .screens.slice(0, -1)
-        .map((s) => s.id);
-      const allButLastScreenGestures = Object.fromEntries(
-        Object.entries(methods.getValues().gestures).filter(([id, _]) =>
-          allButLastScreenIds.includes(id),
-        ),
-      );
-      // Validate the "gestures"
-      const validation = ScreenGestureSchema.safeParse({
-        ...methods.getValues(),
-        gestures: allButLastScreenGestures,
-      });
-      if (!validation.success) {
-        console.error(validation.error.issues);
-        // Group by screen. GestureSchema validates each field separately, so one
-        // untouched gesture yields three or four issues — "Gesture type is
-        // required", "X coordinate is required", "Y coordinate is required" —
-        // which fired as separate toasts and told the worker neither which
-        // screen to fix nor that "X coordinate" means "place the marker".
-        const currentScreens = methods.getValues().screens;
-        const screenNumberById = new Map(
-          currentScreens.map((screen, index) => [screen.id, index + 1]),
+      // Scanned per screen rather than run through ScreenGestureSchema. Zod skips
+      // a `.refine` when the schema beneath it already failed, and the three ways
+      // an annotation can be incomplete sit at three different levels: a missing
+      // marker fails field validation, an unfilled template fails
+      // GestureSchema's refine, and a screen with no gesture at all fails
+      // ScreenGestureSchema's refine. Any field-level failure therefore silenced
+      // the other two, so a worker fixed one screen, pressed Next, and only then
+      // discovered the next problem.
+      //
+      // isScreenAnnotationComplete is the same predicate the filmstrip uses for
+      // its error ring, so what is flagged here is what is ringed there.
+      const { screens: currentScreens, gestures: currentGestures } =
+        methods.getValues();
+      // The last screen is the goal state and needs no gesture.
+      const incompleteScreenNumbers = currentScreens
+        .slice(0, -1)
+        .map((screen, index) => ({ screen, screenNumber: index + 1 }))
+        .filter(
+          ({ screen }) =>
+            !isScreenAnnotationComplete(currentGestures[screen.id]),
+        )
+        .map(({ screenNumber }) => screenNumber);
+
+      if (incompleteScreenNumbers.length > 0) {
+        toast.error(
+          incompleteScreenNumbers.length === 1
+            ? `Screen ${incompleteScreenNumbers[0]} needs a gesture, a marker on the screen, and a complete description.`
+            : `${incompleteScreenNumbers.length} screens still need work: ${incompleteScreenNumbers.join(", ")}.`,
         );
-        const flaggedScreenNumbers = new Set<number>();
-        const otherMessages = new Set<string>();
-
-        validation.error.issues.forEach((issue) => {
-          const [field, screenId] = issue.path;
-          if (field === "gestures" && typeof screenId === "string") {
-            const screenNumber = screenNumberById.get(screenId);
-            if (screenNumber !== undefined) {
-              flaggedScreenNumbers.add(screenNumber);
-              return;
-            }
-          }
-          otherMessages.add(issue.message);
-        });
-
-        if (flaggedScreenNumbers.size > 0) {
-          const screenList = Array.from(flaggedScreenNumbers).sort(
-            (a, b) => a - b,
-          );
-          toast.error(
-            screenList.length === 1
-              ? `Screen ${screenList[0]} needs a gesture with a description.`
-              : `These screens need a gesture with a description: ${screenList.join(", ")}.`,
-          );
-        }
-        otherMessages.forEach((message) => toast.error(message));
-
         setIsSubmitting(false);
         return;
       }

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -36,7 +36,12 @@ import RedactScreen from "./components/redact-screen";
 import { RedactScreenJumpTarget } from "./components/redact-screen/redact-screen";
 import RedactDoc from "./components/redact-screen/doc.mdx";
 
-import { DraftFetchResults, getDraftFiles, handleDraftSave } from "./util";
+import {
+  DraftFetchResults,
+  dedupeScreensById,
+  getDraftFiles,
+  handleDraftSave,
+} from "./util";
 import { revalidateCaptureCaches, updateCapture } from "@/lib/actions";
 import { CaptureStatus } from "@prisma/client";
 import { generateSignedCloudFrontURL } from "@/lib/aws/s3/server";
@@ -208,10 +213,13 @@ export default function Page() {
       }
 
       if (!hasScreensWithSrc) {
+        // Screen id keys selection, gestures, redactions and VHs, so a repeated
+        // id in a draft would make all four ambiguous.
+        const draftScreens = dedupeScreensById(draftFormData.screens);
         // grab screens
         methods.setValue(
           "screens",
-          draftFormData.screens.map((screen) => ({
+          draftScreens.map((screen) => ({
             id: screen.id,
             src: "",
             timestamp: screen.timestamp,
@@ -219,7 +227,7 @@ export default function Page() {
         );
         // grab vh from android screens
         const draftVHs: { [key: string]: any } = {};
-        draftFormData.screens.forEach((screen) => {
+        draftScreens.forEach((screen) => {
           draftVHs[screen.id] = null;
         });
         methods.setValue("vhs", draftVHs);

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -42,6 +42,7 @@ import RedactDoc from "./components/redact-screen/doc.mdx";
 
 import {
   DraftFetchResults,
+  countUnlabelledRedactions,
   dedupeScreensById,
   getDraftFiles,
   handleDraftSave,
@@ -105,6 +106,56 @@ function collectIncompleteScreens(
       issue: getScreenAnnotationIssue(gestures[screen.id]),
     }))
     .filter((entry): entry is IncompleteScreen => entry.issue !== null);
+}
+
+type UnlabelledRedactionScreen = {
+  screenNumber: number;
+  boxCount: number;
+};
+
+/**
+ * Screens carrying redaction boxes with no label, numbered the way the filmstrip
+ * numbers them.
+ *
+ * Scanned rather than parsed for the same reason as `collectIncompleteScreens`:
+ * `RedactionSchema`'s refine returns on the first unlabelled box and reports one
+ * record-level message, so it can say neither which screen nor how many boxes.
+ *
+ * Slightly stricter than the schema, which only rejects an empty string — a
+ * whitespace-only label is no more useful to a reviewer than a blank one.
+ */
+function collectUnlabelledRedactions(
+  screens: TraceFormData["screens"],
+  redactions: TraceFormData["redactions"],
+): UnlabelledRedactionScreen[] {
+  return screens
+    .map((screen, index) => ({
+      screenNumber: index + 1,
+      boxCount: countUnlabelledRedactions(redactions[screen.id]),
+    }))
+    .filter((entry) => entry.boxCount > 0);
+}
+
+/** One message naming the screens whose redaction boxes still need labels. */
+function describeUnlabelledRedactions(
+  entries: UnlabelledRedactionScreen[],
+): string {
+  const describe = (entry: UnlabelledRedactionScreen) =>
+    `Screen ${entry.screenNumber}: label ${
+      entry.boxCount === 1
+        ? "the redaction box"
+        : `${entry.boxCount} redaction boxes`
+    }`;
+
+  if (entries.length === 1) {
+    return `${describe(entries[0])}.`;
+  }
+  if (entries.length <= 4) {
+    return `${entries.length} screens need work — ${entries.map(describe).join("; ")}.`;
+  }
+  return `${entries.length} screens have unlabelled redaction boxes: ${entries
+    .map((entry) => entry.screenNumber)
+    .join(", ")}.`;
 }
 
 /**
@@ -635,16 +686,29 @@ export default function Page() {
         return;
       }
     } else if (stepIndex === TraceSteps.Redact) {
-      // Validate the "redactions"
-      const validation = RedactionSchema.safeParse(
-        methods.getValues().redactions,
+      const { screens: currentScreens, redactions: currentRedactions } =
+        methods.getValues();
+      // Unlabelled boxes first, named per screen. The schema can only say "each
+      // redaction must have an annotation", which leaves the worker opening
+      // screens one by one to find out where.
+      const unlabelledRedactions = collectUnlabelledRedactions(
+        currentScreens,
+        currentRedactions,
       );
+      if (unlabelledRedactions.length > 0) {
+        toast.error(describeUnlabelledRedactions(unlabelledRedactions));
+        setIsSubmitting(false);
+        return;
+      }
+
+      // Then the structural check, for anything malformed the UI should not be
+      // able to produce.
+      const validation = RedactionSchema.safeParse(currentRedactions);
       if (!validation.success) {
         console.error(validation.error.issues);
-        const errors = validation.error.issues || "Invalid input";
-        errors.forEach((error) => {
-          toast.error(error.message);
-        });
+        new Set(validation.error.issues.map((issue) => issue.message)).forEach(
+          (message) => toast.error(message),
+        );
         setIsSubmitting(false);
         return;
       }

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -587,10 +587,42 @@ export default function Page() {
       });
       if (!validation.success) {
         console.error(validation.error.issues);
-        const errors = validation.error.issues || "Invalid input";
-        errors.forEach((error) => {
-          toast.error(error.message);
+        // Group by screen. GestureSchema validates each field separately, so one
+        // untouched gesture yields three or four issues — "Gesture type is
+        // required", "X coordinate is required", "Y coordinate is required" —
+        // which fired as separate toasts and told the worker neither which
+        // screen to fix nor that "X coordinate" means "place the marker".
+        const currentScreens = methods.getValues().screens;
+        const screenNumberById = new Map(
+          currentScreens.map((screen, index) => [screen.id, index + 1]),
+        );
+        const flaggedScreenNumbers = new Set<number>();
+        const otherMessages = new Set<string>();
+
+        validation.error.issues.forEach((issue) => {
+          const [field, screenId] = issue.path;
+          if (field === "gestures" && typeof screenId === "string") {
+            const screenNumber = screenNumberById.get(screenId);
+            if (screenNumber !== undefined) {
+              flaggedScreenNumbers.add(screenNumber);
+              return;
+            }
+          }
+          otherMessages.add(issue.message);
         });
+
+        if (flaggedScreenNumbers.size > 0) {
+          const screenList = Array.from(flaggedScreenNumbers).sort(
+            (a, b) => a - b,
+          );
+          toast.error(
+            screenList.length === 1
+              ? `Screen ${screenList[0]} needs a gesture with a description.`
+              : `These screens need a gesture with a description: ${screenList.join(", ")}.`,
+          );
+        }
+        otherMessages.forEach((message) => toast.error(message));
+
         setIsSubmitting(false);
         return;
       }

--- a/src/app/(signed-in)/capture/[captureId]/edit/util/dedupe-screens.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/util/dedupe-screens.ts
@@ -1,0 +1,28 @@
+/**
+ * Drops screens whose id has already been seen, keeping the first occurrence.
+ *
+ * Screen id is the key for selection, gestures, redactions and view hierarchies,
+ * so a duplicate makes all four ambiguous: two filmstrip entries highlight as
+ * selected at once, and deleting one removes whichever matches first rather than
+ * the one that was clicked. Position used to disambiguate this; identity does
+ * not. Drafts are external JSON written by earlier versions of the editor, so
+ * the invariant is enforced on the way in rather than assumed.
+ *
+ * @param screens - Screens as loaded from a draft or capture metadata file.
+ * @returns The same screens in order, minus later entries repeating an id.
+ */
+export function dedupeScreensById<T extends { id: string }>(
+  screens: T[],
+): T[] {
+  const seenIds = new Set<string>();
+  return screens.filter((screen) => {
+    if (seenIds.has(screen.id)) {
+      console.warn(
+        `Dropping screen with duplicate id "${screen.id}" while loading draft.`,
+      );
+      return false;
+    }
+    seenIds.add(screen.id);
+    return true;
+  });
+}

--- a/src/app/(signed-in)/capture/[captureId]/edit/util/index.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/util/index.ts
@@ -1,2 +1,3 @@
 export * from "./export";
 export * from "./vh-parse";
+export * from "./dedupe-screens";

--- a/src/app/(signed-in)/capture/[captureId]/edit/util/index.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/util/index.ts
@@ -1,3 +1,4 @@
 export * from "./export";
 export * from "./vh-parse";
 export * from "./dedupe-screens";
+export * from "./redaction-completeness";

--- a/src/app/(signed-in)/capture/[captureId]/edit/util/redaction-completeness.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/util/redaction-completeness.ts
@@ -1,0 +1,28 @@
+/** A redaction box only needs its label for these checks. */
+type LabelledRedaction = { annotation?: string | null };
+
+/**
+ * Whether a redaction box carries a usable label.
+ *
+ * Stricter than `RedactionSchema`, which only rejects an empty string: a
+ * whitespace-only label is no more useful to a reviewer than a blank one.
+ */
+export function isRedactionLabelled(redaction: LabelledRedaction): boolean {
+  return (redaction.annotation ?? "").trim().length > 0;
+}
+
+/**
+ * How many of a screen's redaction boxes still need a label.
+ *
+ * Shared by the redact filmstrip's error ring and the step gate in page.tsx so
+ * the screens flagged in one are exactly the screens named by the other.
+ *
+ * @param redactions - A screen's redaction boxes, if it has any.
+ */
+export function countUnlabelledRedactions(
+  redactions: LabelledRedaction[] | undefined,
+): number {
+  return (redactions ?? []).filter(
+    (redaction) => !isRedactionLabelled(redaction),
+  ).length;
+}


### PR DESCRIPTION
Follow-on to #186. Three pieces of work plus the defects that QA surfaced along the way.

## Why

#186 fixed a focus jump, a phantom screen capture, and needed two attempts to make a seek land. All three traced to one thing: **nothing owns "where the workspace is."** Screen selection was a positional index, playhead position lived in the DOM element mirrored by `currentTime`, and the displayed frame was a third thing again — a thumbnail overlay. Every writer raced the others.

This branch fixes two of those and makes the third honest. Plan and sequencing live in `plans/features/v6-annotate-workspace-state-reorg.md`.

## 1. The preview no longer lies

The video panel hides the real `<video>` behind a thumbnail whenever an overlay is up, and the overlay was never taken down while paused. Preview thumbnails are nearest-neighbour picks off a coarse grid — 90 thumbs across a 106s recording, ~1.18s apart, so **up to ±0.59s from the playhead**. Meanwhile `c` captures the accurate frame at `currentTime`, so what a worker aimed at and what they captured could disagree by half a second.

That plausibly manufactured some of the `captured_before_loading` and `screen_captured_after_gesture` rejections the evaluate step penalizes — the tool was inducing the errors it then flagged. It also made frame stepping look inert: `,`/`.` move 1/30s, but the image only changed on crossing a ~1.18s boundary.

The overlay now covers seek latency and then gets out of the way. Two rounds to get right: the first attempt gated the reveal on `videoDuration > 0`, which is set too early — bootstrap keeps seeking the live element to extract frames, and its warmup grab dragged the playhead to 0.1s. The second gated on the landed position matching the request within a millisecond, which browsers rarely satisfy because they snap to the nearest decodable frame; QA caught the resulting intermittent staleness. It now waits for the playhead to come to rest.

While an overlay *is* up, a small badge marks the frame as approximate, so the correction reads as the picture sharpening rather than the tool changing its mind.

## 2. Selection is keyed by screen id

`focusViewIndex` was positional, so inserting a screen earlier in the trace shifted every later position while the state stayed put — focus silently moved to a neighbour. Workers hit this routinely, because the feedback asks them to add missing screens.

`NavigationContext` now carries `focusedScreenId`, with `focusedIndex` derived once in the provider so ordering questions have one answer instead of one per consumer. Deletion takes an id, and the filmstrip's scroll-into-view queries `data-screen-id`.

Redact keeps its positional index: same shape, but screens are never inserted or deleted there, so the bug is unreachable and including it would only widen the diff.

## 3. Validation names the screens and says what they need

Three different ways an annotation can be incomplete sat at three different levels, and **zod skips a `.refine` once the schema beneath it fails** — so any field-level failure hid the rest:

| incomplete because | failed at | was reported? |
| --- | --- | --- |
| no marker placed | field validation on `x`/`y` | yes |
| template slots unfilled | `GestureSchema.refine` | no |
| no gesture at all | `ScreenGestureSchema.refine` | no |

A worker fixed the one screen named, pressed Next, and only then learned about the next. Both the capture gate and the final submit gate now scan per screen through `getScreenAnnotationIssue`, which reports the first unmet requirement as an instruction — add a gesture, choose a type, place it on the screen, add the drag end point, finish the description. The filmstrip's error ring calls the same predicate, which also settles a disagreement between them: the ring ignored marker placement while the gate required it, so a screen could look finished and still block the step.

Redact had the same shape — one record-level message that named neither the screen nor the count — and gets the same treatment, plus its filmstrip error ring, which the item component already supported but the parent never passed.

`ScreenGestureSchema` is deleted; it had no callers left, and dead validation invites edits that change nothing.

## Defects QA found, now fixed

- **Keyboard navigation could get trapped.** `handleNext` refused to leave a screen with an incomplete gesture, so a screen captured near the end was unreachable by keyboard. That guard enforced nothing — Previous was free, clicking a filmstrip item or a feedback chip bypassed it, and it was silent. Removed; the step gates enforce, and the filmstrip rings.
- **Capture left focus behind**, so the worker hunted the new frame down before annotating it. Focus now follows the capture — a one-liner *because* selection is keyed by id.
- **Screen-id uniqueness became load-bearing** once selection resolved by id. Drafts are external JSON, so duplicates are dropped on the way in.

## Verification

- `type-check`, `lint`, and a production build clean.
- Guard logic exercised against real `react-hook-form` broadcasts: chip click plus 10 keystrokes goes from 11 focus changes to 1, while new/repeat chip clicks and the load-order retry still jump exactly once.
- Manual QA by @carlguo2 across the branch: original repros, navigation, capture focus, delete-after-insert, scrub-and-release, and all three validation gates.

Secondary win worth noting: dropping the completeness guard let `RepairScreen` drop its `gestures` subscription, so it no longer re-renders on every keystroke in the annotation editor — the same deep-clone-per-write behaviour that caused the original focus jump.

## Deliberately deferred

- **Revealing the real frame during a held drag.** The accurate frame is already being seeked ~8×/sec mid-drag and is simply hidden. Doing it now needs a fourth interleaved timer plus handling `handleScrubCommit` re-showing the thumbnail on mouseup; after the state-ownership work it is a derived condition. First item after that lands. The badge is the interim measure.
- **The `,`/`.` flicker**, which needs the preview to know a seek was step-driven rather than drag-driven — the same source-tagging.
- `registerSeekToTime`, the pending-seek ref, and the `isVideoReady` gate are plumbing that the ownership work retires. Their deletion is the point, not a regression.
- `dedupeScreensById` covers the draft path only; Android's `original-metadata.json` is a second external source with the same exposure.

## Note for merging

GitHub Actions is in a [major outage](https://www.githubstatus.com/), so `type-check-and-lint` may not report. Both steps it runs pass locally against this tree, as does a production build, which CI does not check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
