### PR TITLE
refactor(annotate): single owner for selection and playhead, plus faster bootstrap

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,10 @@ export default defineConfig([
     ".venv/**",
     "dist/**",
     "out/**",
+    // Gitignored agent scratch space: plans, and throwaway spikes that vendor
+    // third-party builds. CI never sees it, but linting it locally reports
+    // problems in code nobody here wrote or ships.
+    "plans/**",
     "src/app/(signed-in)/_trace/**",
   ]),
   ...compat.extends("next/core-web-vitals"),

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/android/repair-screen-android.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/android/repair-screen-android.tsx
@@ -231,7 +231,6 @@ export function RepairScreenAndroid({
             gestures={currGestures}
             redactions={currRedactions}
             os={os}
-            handleSetTime={(_: number) => {}} // empty function
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
@@ -23,16 +23,13 @@ export function Filmstrip({
   gestures,
   redactions,
   os,
-  handleSetTime,
 }: {
   screens: FrameData[];
   gestures: { [key: string]: ScreenGesture };
   redactions: { [screenId: string]: Redaction[] };
   os: Platform;
-  handleSetTime: (t: number) => void;
 }) {
-  const { focusedScreenId, setFocusedScreenId, handleDeleteScreen } =
-    useNavigation();
+  const { focusedScreenId, selectScreen, handleDeleteScreen } = useNavigation();
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -93,8 +90,7 @@ export function Filmstrip({
                 hasError={
                   isLast ? false : !isScreenAnnotationComplete(gestures[screen.id])
                 }
-                onClick={() => setFocusedScreenId(screen.id)}
-                handleSetTime={handleSetTime}
+                onClick={() => selectScreen(screen.id, "filmstrip")}
                 handleDeleteFrame={handleDeleteScreen}
               />
             );
@@ -113,7 +109,6 @@ function FilmstripItem({
   os,
   isSelected,
   hasError = false,
-  handleSetTime,
   handleDeleteFrame,
   onClick,
 }: {
@@ -124,7 +119,6 @@ function FilmstripItem({
   os: Platform;
   isSelected?: boolean;
   hasError?: boolean;
-  handleSetTime: (t: number) => void;
   handleDeleteFrame: (screenId: string) => void;
   onClick?: () => void;
 }) {
@@ -145,10 +139,7 @@ function FilmstripItem({
       layout="position"
       transition={spring()}
       key={`${screen.timestamp}-${screen.id}`}
-      onClick={() => {
-        onClick?.();
-        handleSetTime(screen.timestamp);
-      }}
+      onClick={onClick}
     >
       {/* Toolbar */}
       <div className="flex flex-row w-full items-center justify-between">

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/extract-frames-timeline.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/extract-frames-timeline.tsx
@@ -34,7 +34,7 @@ export type FrameTimelineProps = {
   currentTime: number;
   videoDuration: number;
   isPlaying: boolean;
-  handleSetTime: (t: number) => void;
+  handleSetTime: (t: number, options?: { syncFocus?: boolean }) => void;
   handlePlayPause: () => void;
   handleCapture: () => void;
   onScrubPreviewTimeChange?: (t: number | null) => void;
@@ -164,14 +164,16 @@ export default function FrameTimeline({
     ? { type: "tween" as const, ease: "linear" as const, duration: 0.04 }
     : spring({ duration: 0.12 });
 
+  // Mouse equivalents of the j/l keys, so they drag the focused screen along
+  // the same way an explicit seek does.
   const handleSkipForward = () => {
     const newTime = Math.min(currentTime + 5, videoDuration);
-    handleSetTime(newTime);
+    handleSetTime(newTime, { syncFocus: true });
   };
 
   const handleSkipBackward = () => {
     const newTime = Math.max(currentTime - 5, 0);
-    handleSetTime(newTime);
+    handleSetTime(newTime, { syncFocus: true });
   };
 
   const displayedThumbnails = useMemo(() => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
@@ -5,7 +5,19 @@ export const TIMELINE_THUMB_HEIGHT = 128;
 export const PREVIEW_THUMB_HEIGHT = 1440;
 export const TIMELINE_THUMB_JPEG_QUALITY = 0.84;
 export const PREVIEW_THUMB_JPEG_QUALITY = 0.9;
-export const SCRUB_SEEK_INTERVAL_MS = 125;
+/**
+ * Minimum gap between seeks while scrubbing.
+ *
+ * Exists because assigning `currentTime` while a seek is in flight aborts it and
+ * starts over, so an unthrottled drag could thrash the decoder badly enough that
+ * no seek ever completed — the original reason scrubbing appeared to break.
+ *
+ * Measured seek-to-frame-presented latency is 14-38ms median and 30-93ms at p95
+ * across Chrome and Safari, so the old 125ms was throttling several times slower
+ * than the hardware and holding back both the frame rate during a drag and how
+ * quickly the real frame appears once the pointer stops.
+ */
+export const SCRUB_SEEK_INTERVAL_MS = 70;
 export const FRAME_STEP_SECONDS = 1 / 30;
 export const STEP_COMMIT_DELAY_MS = 120;
 export const PREVIEW_SWAP_DELAY_MS = 70;

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
@@ -16,6 +16,12 @@ export const PREVIEW_SWAP_DELAY_MS = 70;
  * element is showing what was asked for.
  */
 export const PREVIEW_MATCH_TOLERANCE = 2 / 30;
+/**
+ * Backstop for uncovering the video when `requestVideoFrameCallback` is missing
+ * or never fires. Long enough that a normal presentation wins the race, short
+ * enough that a worker does not sit looking at a thumbnail.
+ */
+export const PREVIEW_REVEAL_TIMEOUT_MS = 250;
 export const VIDEO_LOAD_TIMEOUT_MS = 30000;
 
 export type PreviewThumbnail = {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
@@ -9,6 +9,13 @@ export const SCRUB_SEEK_INTERVAL_MS = 125;
 export const FRAME_STEP_SECONDS = 1 / 30;
 export const STEP_COMMIT_DELAY_MS = 120;
 export const PREVIEW_SWAP_DELAY_MS = 70;
+/**
+ * How close the landed frame has to be to the requested moment before the real
+ * video can replace the thumbnail. Browsers snap to the nearest decodable frame,
+ * so an exact match never holds; two frames at 30fps is close enough that the
+ * element is showing what was asked for.
+ */
+export const PREVIEW_MATCH_TOLERANCE = 2 / 30;
 export const VIDEO_LOAD_TIMEOUT_MS = 30000;
 
 export type PreviewThumbnail = {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -35,12 +35,8 @@ export function RepairScreenIOS({
   os: Platform;
   draftFetchResult: DraftFetchResults;
 }) {
-  const {
-    focusedScreenId,
-    setFocusedScreenId,
-    focusedIndex,
-    registerSeekToTime,
-  } = useNavigation();
+  const { focusedScreenId, selectScreen, focusedIndex, playheadRequest } =
+    useNavigation();
   const { setValue } = useFormContext<TraceFormData>();
   const { register: registerScreenUrl } = useScreenBlobRegistry();
   const [watchScreens, watchGestures, watchRedactions] = useWatch({
@@ -64,8 +60,8 @@ export function RepairScreenIOS({
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const didKeyPressStartInFormField = useFormFieldKeyPressGuard();
-  // Holds a jump's seek target while the recording is still loading.
-  const pendingJumpSeekRef = useRef<number | null>(null);
+  // Highest playhead request already applied, so each is placed once.
+  const appliedPlayheadNonceRef = useRef<number | null>(null);
 
   const videoFiles = useMemo(() => {
     const regexRule = /\.(mp4|mov)$/;
@@ -89,7 +85,7 @@ export function RepairScreenIOS({
   const { syncFocusToTimestamp } = useIosScreenFocusSync({
     screens,
     focusedScreenId,
-    setFocusedScreenId,
+    selectScreen,
   });
 
   // Bootstrap: load video, populate screens, expose duration + thumbnails.
@@ -152,39 +148,27 @@ export function RepairScreenIOS({
     syncFocusToTimestamp,
   });
 
-  // Let a jump to a screen (feedback checklist chip) carry the playhead with it.
-  // `syncFocus: false` matters: handleSetTime otherwise re-derives focus from the
-  // nearest screen timestamp, which lands on a neighbour when two screens sit
-  // close together and would override the jump that asked for this seek.
+  // Reconcile the recording towards where it has been asked to sit.
+  //
+  // Declarative on purpose. Bootstrap seeks the live element while extracting
+  // frames — the warmup grab alone drags it to 0.1s — so a seek issued during
+  // loading gets undone. Expressing the target as state means this effect simply
+  // runs again once `isVideoReady` flips, instead of a queue trying to guess the
+  // right moment to fire.
+  //
+  // No focus sync: the request came *from* a selection, and re-deriving focus
+  // from the landed timestamp is what let a click settle on a neighbouring
+  // screen when two sit close together.
   useEffect(() => {
-    registerSeekToTime((timestamp) => {
-      // Bootstrap seeks the live video element while extracting frames — the
-      // warmup grab alone drags it to 0.1s — and the `seeked` listener writes
-      // that back over currentTime. Seeking before it finishes gets undone, and
-      // a jump applies only once, so it never self-corrects. Hold it instead.
-      if (!isVideoReady) {
-        pendingJumpSeekRef.current = timestamp;
-        return;
-      }
-      handleSetTime(timestamp, { syncFocus: false });
-    });
-    return () => registerSeekToTime(null);
-  }, [handleSetTime, isVideoReady, registerSeekToTime]);
-
-  // Place a jump seek that arrived while the recording was still loading.
-  // Reachable whenever the step is re-entered with a jump still armed: this
-  // component and the video both remount, so the jump lands mid-bootstrap.
-  useEffect(() => {
-    if (!isVideoReady) {
+    if (!playheadRequest || !isVideoReady) {
       return;
     }
-    const pendingSeek = pendingJumpSeekRef.current;
-    if (pendingSeek === null) {
+    if (appliedPlayheadNonceRef.current === playheadRequest.nonce) {
       return;
     }
-    pendingJumpSeekRef.current = null;
-    handleSetTime(pendingSeek, { syncFocus: false });
-  }, [handleSetTime, isVideoReady]);
+    appliedPlayheadNonceRef.current = playheadRequest.nonce;
+    handleSetTime(playheadRequest.time);
+  }, [handleSetTime, isVideoReady, playheadRequest]);
 
   // Now that scrub-preview exists, point the lazy refs at the real callbacks.
   useEffect(() => {
@@ -221,8 +205,8 @@ export function RepairScreenIOS({
     // so capturing is always followed by annotating it — and leaving focus
     // behind meant hunting for the new frame in the filmstrip first. No seek is
     // needed: the playhead is already at this screen's timestamp.
-    setFocusedScreenId(f.id);
-  }, [currentTime, registerScreenUrl, screens, setFocusedScreenId, setValue]);
+    selectScreen(f.id, "capture");
+  }, [currentTime, registerScreenUrl, screens, selectScreen, setValue]);
 
   // Workspace keybinds
   useHotkeys("space", async (e) => {
@@ -249,7 +233,7 @@ export function RepairScreenIOS({
     "j",
     (e) => {
       e.preventDefault();
-      handleSetTime(currentTime - 5);
+      handleSetTime(currentTime - 5, { syncFocus: true });
     },
     [currentTime, handleSetTime],
   );
@@ -258,7 +242,7 @@ export function RepairScreenIOS({
     "l",
     (e) => {
       e.preventDefault();
-      handleSetTime(currentTime + 5);
+      handleSetTime(currentTime + 5, { syncFocus: true });
     },
     [currentTime, handleSetTime],
   );
@@ -338,7 +322,6 @@ export function RepairScreenIOS({
               gestures={gestures}
               redactions={redactions}
               os={os}
-              handleSetTime={handleSetTime}
             />
             <FrameTimeline
               thumbnails={thumbnails}

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -187,6 +187,7 @@ export function RepairScreenIOS({
     scheduleScrubSeek,
     handleScrubCommit,
     setPausedPreviewTime,
+    onScrubActiveChange: handleScrubActiveChange,
   });
 
   const handleCaptureFrame = useCallback(async () => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
@@ -1,13 +1,23 @@
 /**
- * Temporary instrumentation for deciding whether the thumbnail preview pipeline
- * can be replaced by native video seeking.
+ * Instrumentation for the scrub pipeline.
  *
- * Measures the two numbers that decide it:
+ * Written to answer whether the thumbnail preview could be replaced by native
+ * video seeking. It could not, and the numbers that settled it are worth keeping
+ * around:
  *
  *  - how long a seek takes to actually put a frame on screen, and how often that
- *    never happens (the reason native scrubbing felt broken before), and
- *  - how much of bootstrap is spent extracting preview thumbnails, which is what
- *    going native would buy back.
+ *    never happens, and
+ *  - how much of bootstrap is spent extracting preview thumbnails.
+ *
+ * It has since earned a second job. `stalls` distinguishes the two browsers in a
+ * way nothing else here does: `requestVideoFrameCallback` fires for a paused seek
+ * in Chrome and never fires in Safari, so a Safari session reports every seek as
+ * a stall while Chrome reports none. That is the same underlying fault as
+ * <https://bugs.webkit.org/show_bug.cgi?id=153588>, which is why the settled
+ * frame can be wrong on Safari and is not wrong on Chrome.
+ *
+ * So this is not dead code awaiting deletion — it is how that bug gets measured
+ * next time, and how any audit of already-captured screens would be checked.
  *
  * Off unless switched on, so it costs a boolean check per seek otherwise. Enable
  * with `?scrubProfiling=1` on the URL, or persistently:
@@ -15,8 +25,6 @@
  *     localStorage.setItem("odim:scrub-profiling", "1")
  *
  * Then scrub around and call `__odimScrubProfile.summary()` in the console.
- *
- * Delete this file once the question is settled.
  */
 
 type VideoWithFrameCallback = HTMLVideoElement & {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
@@ -1,0 +1,240 @@
+/**
+ * Temporary instrumentation for deciding whether the thumbnail preview pipeline
+ * can be replaced by native video seeking.
+ *
+ * Measures the two numbers that decide it:
+ *
+ *  - how long a seek takes to actually put a frame on screen, and how often that
+ *    never happens (the reason native scrubbing felt broken before), and
+ *  - how much of bootstrap is spent extracting preview thumbnails, which is what
+ *    going native would buy back.
+ *
+ * Off unless switched on, so it costs a boolean check per seek otherwise. Enable
+ * with `?scrubProfiling=1` on the URL, or persistently:
+ *
+ *     localStorage.setItem("odim:scrub-profiling", "1")
+ *
+ * Then scrub around and call `__odimScrubProfile.summary()` in the console.
+ *
+ * Delete this file once the question is settled.
+ */
+
+type VideoWithFrameCallback = HTMLVideoElement & {
+  requestVideoFrameCallback?: (
+    callback: (now: number, metadata: { mediaTime: number }) => void,
+  ) => number;
+  cancelVideoFrameCallback?: (handle: number) => void;
+};
+
+interface SeekSample {
+  /** Where the seek asked to land. */
+  requestedTime: number;
+  /** Where the presented frame actually was, when the browser reports it. */
+  presentedTime: number | null;
+  /** Issue to presentation, in milliseconds. */
+  latencyMs: number;
+  /** Never presented within the stall threshold. */
+  stalled: boolean;
+}
+
+/** A seek not presented within this long counts as a stall, not slow. */
+const STALL_THRESHOLD_MS = 1000;
+
+const samples: SeekSample[] = [];
+const phaseTimings: Record<string, number[]> = {};
+let supersededCount = 0;
+let isEnabledCache: boolean | null = null;
+let isInstalled = false;
+
+let inFlight: {
+  requestedTime: number;
+  startedAt: number;
+  frameHandle: number | null;
+  stallTimeout: number | null;
+} | null = null;
+
+export function isScrubProfilingEnabled(): boolean {
+  if (isEnabledCache !== null) {
+    return isEnabledCache;
+  }
+  if (typeof window === "undefined") {
+    return false;
+  }
+  let enabled = false;
+  try {
+    enabled = window.localStorage.getItem("odim:scrub-profiling") === "1";
+  } catch {
+    // Storage can be unavailable; the query parameter still works.
+  }
+  if (!enabled) {
+    enabled = new URLSearchParams(window.location.search).has("scrubProfiling");
+  }
+  isEnabledCache = enabled;
+  return enabled;
+}
+
+function percentile(sorted: number[], fraction: number): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(sorted.length * fraction) - 1),
+  );
+  return sorted[index];
+}
+
+function round(value: number, places = 1): number {
+  const factor = 10 ** places;
+  return Math.round(value * factor) / factor;
+}
+
+function summary() {
+  const presented = samples.filter((sample) => !sample.stalled);
+  const latencies = presented
+    .map((sample) => sample.latencyMs)
+    .sort((a, b) => a - b);
+  const errors = presented
+    .filter((sample) => sample.presentedTime !== null)
+    .map((sample) =>
+      Math.abs((sample.presentedTime as number) - sample.requestedTime),
+    )
+    .sort((a, b) => a - b);
+
+  const result = {
+    seeks: samples.length,
+    presented: presented.length,
+    stalls: samples.filter((sample) => sample.stalled).length,
+    /** Seeks abandoned because the pointer moved on before they landed. */
+    superseded: supersededCount,
+    latencyMsP50: round(percentile(latencies, 0.5)),
+    latencyMsP95: round(percentile(latencies, 0.95)),
+    latencyMsMax: round(latencies[latencies.length - 1] ?? 0),
+    /** How far the presented frame sat from the requested moment, in seconds. */
+    frameErrorSecP50: round(percentile(errors, 0.5), 3),
+    frameErrorSecMax: round(errors[errors.length - 1] ?? 0, 3),
+  };
+
+  const phases = Object.fromEntries(
+    Object.entries(phaseTimings).map(([name, values]) => [
+      name,
+      {
+        runs: values.length,
+        totalMs: round(values.reduce((sum, value) => sum + value, 0)),
+        lastMs: round(values[values.length - 1] ?? 0),
+      },
+    ]),
+  );
+
+  console.table(result);
+  console.table(phases);
+  return { ...result, phases };
+}
+
+function reset() {
+  samples.length = 0;
+  supersededCount = 0;
+  Object.keys(phaseTimings).forEach((key) => delete phaseTimings[key]);
+}
+
+function install() {
+  if (isInstalled || typeof window === "undefined") {
+    return;
+  }
+  isInstalled = true;
+  (
+    window as unknown as { __odimScrubProfile: unknown }
+  ).__odimScrubProfile = { summary, reset, samples, phaseTimings };
+  console.info(
+    "[scrub-profiler] recording. Call __odimScrubProfile.summary() when done.",
+  );
+}
+
+function settleInFlight(presentedTime: number | null, stalled: boolean) {
+  if (!inFlight) {
+    return;
+  }
+  if (inFlight.stallTimeout !== null) {
+    window.clearTimeout(inFlight.stallTimeout);
+  }
+  samples.push({
+    requestedTime: inFlight.requestedTime,
+    presentedTime,
+    latencyMs: performance.now() - inFlight.startedAt,
+    stalled,
+  });
+  inFlight = null;
+}
+
+/**
+ * Call immediately after assigning `video.currentTime`.
+ *
+ * Timing ends when the browser reports a frame presented, which is the moment
+ * the worker can actually see it — `seeked` fires earlier and would flatter the
+ * numbers.
+ */
+export function recordSeekIssued(
+  video: HTMLVideoElement,
+  requestedTime: number,
+): void {
+  if (!isScrubProfilingEnabled()) {
+    return;
+  }
+  install();
+
+  const videoWithCallback = video as VideoWithFrameCallback;
+
+  if (inFlight) {
+    // The pointer moved on before this one landed. Not a stall — the opposite,
+    // it says the decoder is behind the input.
+    if (inFlight.frameHandle !== null) {
+      videoWithCallback.cancelVideoFrameCallback?.(inFlight.frameHandle);
+    }
+    if (inFlight.stallTimeout !== null) {
+      window.clearTimeout(inFlight.stallTimeout);
+    }
+    inFlight = null;
+    supersededCount += 1;
+  }
+
+  const started = performance.now();
+  inFlight = {
+    requestedTime,
+    startedAt: started,
+    frameHandle: null,
+    stallTimeout: window.setTimeout(
+      () => settleInFlight(null, true),
+      STALL_THRESHOLD_MS,
+    ),
+  };
+
+  if (typeof videoWithCallback.requestVideoFrameCallback === "function") {
+    inFlight.frameHandle = videoWithCallback.requestVideoFrameCallback(
+      (_now, metadata) => settleInFlight(metadata.mediaTime, false),
+    );
+    return;
+  }
+
+  // No frame-presentation support: fall back to `seeked`, and note that these
+  // latencies are optimistic by however long painting takes.
+  const onSeeked = () => {
+    video.removeEventListener("seeked", onSeeked);
+    settleInFlight(video.currentTime, false);
+  };
+  video.addEventListener("seeked", onSeeked, { once: true });
+}
+
+/**
+ * Record how long a named bootstrap phase took.
+ *
+ * `previewThumbnails` is the one that matters — it is the work that disappears
+ * if the preview pipeline is removed.
+ */
+export function recordPhase(name: string, durationMs: number): void {
+  if (!isScrubProfilingEnabled()) {
+    return;
+  }
+  install();
+  phaseTimings[name] = phaseTimings[name] ?? [];
+  phaseTimings[name].push(durationMs);
+}

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
@@ -35,6 +35,20 @@ interface SeekSample {
   latencyMs: number;
   /** Never presented within the stall threshold. */
   stalled: boolean;
+  /**
+   * Element state captured at stall time, to tell two very different things
+   * apart: an element genuinely stuck mid-seek, which is the failure that makes
+   * native scrubbing unusable, versus a seek that completed while
+   * `requestVideoFrameCallback` simply never fired — a reporting gap with no
+   * effect on what the worker sees.
+   */
+  stallState?: {
+    currentTime: number;
+    seeking: boolean;
+    readyState: number;
+    /** The element sits at the requested moment despite no frame callback. */
+    reachedTarget: boolean;
+  };
 }
 
 /** A seek not presented within this long counts as a stall, not slow. */
@@ -47,6 +61,7 @@ let isEnabledCache: boolean | null = null;
 let isInstalled = false;
 
 let inFlight: {
+  video: HTMLVideoElement;
   requestedTime: number;
   startedAt: number;
   frameHandle: number | null;
@@ -101,10 +116,21 @@ function summary() {
     )
     .sort((a, b) => a - b);
 
+  const stalls = samples.filter((sample) => sample.stalled);
+  // A stall where the element reached the target and is no longer seeking means
+  // the frame was there and only the callback went missing.
+  const unreportedFrames = stalls.filter(
+    (sample) => sample.stallState?.reachedTarget && !sample.stallState.seeking,
+  ).length;
+
   const result = {
     seeks: samples.length,
     presented: presented.length,
-    stalls: samples.filter((sample) => sample.stalled).length,
+    stalls: stalls.length,
+    /** Stalls that were really the element stuck mid-seek. */
+    stalledStuck: stalls.length - unreportedFrames,
+    /** Stalls that were only a missing frame callback. */
+    stalledButFramePresent: unreportedFrames,
     /** Seeks abandoned because the pointer moved on before they landed. */
     superseded: supersededCount,
     latencyMsP50: round(percentile(latencies, 0.5)),
@@ -157,11 +183,21 @@ function settleInFlight(presentedTime: number | null, stalled: boolean) {
   if (inFlight.stallTimeout !== null) {
     window.clearTimeout(inFlight.stallTimeout);
   }
+
+  const { video, requestedTime } = inFlight;
   samples.push({
-    requestedTime: inFlight.requestedTime,
+    requestedTime,
     presentedTime,
     latencyMs: performance.now() - inFlight.startedAt,
     stalled,
+    stallState: stalled
+      ? {
+          currentTime: video.currentTime,
+          seeking: video.seeking,
+          readyState: video.readyState,
+          reachedTarget: Math.abs(video.currentTime - requestedTime) <= 0.05,
+        }
+      : undefined,
   });
   inFlight = null;
 }
@@ -199,6 +235,7 @@ export function recordSeekIssued(
 
   const started = performance.now();
   inFlight = {
+    video,
     requestedTime,
     startedAt: started,
     frameHandle: null,

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-screen-focus-sync.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-screen-focus-sync.ts
@@ -1,17 +1,24 @@
 import { useCallback } from "react";
 import { FrameData } from "../../../types";
+import { SelectScreenSource } from "../../repair-screen";
 import { findNearestScreenIndex } from "./ios-helpers";
 
 interface UseIosScreenFocusSyncArgs {
   screens: FrameData[];
   focusedScreenId: string | null;
-  setFocusedScreenId: (screenId: string | null) => void;
+  selectScreen: (screenId: string | null, source: SelectScreenSource) => void;
 }
 
+/**
+ * Derives the focused screen from a playhead position — the one-way half of the
+ * relationship. Selections made this way are tagged `"playhead"`, which is
+ * excluded from moving the recording, so the derivation cannot feed back into
+ * the position it came from.
+ */
 export function useIosScreenFocusSync({
   screens,
   focusedScreenId,
-  setFocusedScreenId,
+  selectScreen,
 }: UseIosScreenFocusSyncArgs) {
   const getNearestScreenIndex = useCallback(
     (time: number) => findNearestScreenIndex(screens, time),
@@ -26,10 +33,10 @@ export function useIosScreenFocusSync({
       }
       const nextScreenId = screens[nextIndex].id;
       if (nextScreenId !== focusedScreenId) {
-        setFocusedScreenId(nextScreenId);
+        selectScreen(nextScreenId, "playhead");
       }
     },
-    [focusedScreenId, getNearestScreenIndex, screens, setFocusedScreenId],
+    [focusedScreenId, getNearestScreenIndex, screens, selectScreen],
   );
 
   return { getNearestScreenIndex, syncFocusToTimestamp };

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -9,6 +9,7 @@ import {
 } from "react";
 
 
+import { recordSeekIssued } from "./scrub-profiler";
 import {
   PREVIEW_MATCH_TOLERANCE,
   PREVIEW_REVEAL_TIMEOUT_MS,
@@ -243,6 +244,7 @@ export function useIosScrubPreview({
       isSeekInFlightRef.current = true;
       pendingSeekTimeRef.current = nextTime;
       video.currentTime = nextTime;
+      recordSeekIssued(video, nextTime);
       if (scrubPreviewTimeRef.current === null) {
         lastCommittedVideoTimeRef.current = nextTime;
         updateCurrentTime(nextTime);
@@ -463,6 +465,7 @@ export function useIosScrubPreview({
       isSeekInFlightRef.current = true;
       pendingSeekTimeRef.current = t;
       video.currentTime = t;
+      recordSeekIssued(video, t);
       updateCurrentTime(t);
     },
     [

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -311,7 +311,10 @@ export function useIosScrubPreview({
 
       t = Math.max(0, Math.min(t, videoDuration));
 
-      if (options?.syncFocus ?? true) {
+      // Opt-in. A seek only drags the focused screen along when the seek itself
+      // was the worker's intent — scrubbing, frame stepping, the ±5s keys. A seek
+      // that exists because a screen was selected must not reassign selection.
+      if (options?.syncFocus) {
         syncFocusToTimestamp(t);
       }
 

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -11,11 +11,22 @@ import {
 
 import {
   PREVIEW_MATCH_TOLERANCE,
+  PREVIEW_REVEAL_TIMEOUT_MS,
   PREVIEW_SWAP_DELAY_MS,
   PreviewThumbnail,
   SCRUB_SEEK_INTERVAL_MS,
   findNearestPreviewThumbnail,
 } from "./ios-helpers";
+
+/**
+ * `requestVideoFrameCallback` is not in every TypeScript DOM lib, and is absent
+ * on older browsers, so it is described here and feature-detected at the call
+ * site rather than assumed.
+ */
+type VideoWithFrameCallback = HTMLVideoElement & {
+  requestVideoFrameCallback?: (callback: () => void) => number;
+  cancelVideoFrameCallback?: (handle: number) => void;
+};
 
 interface UseIosScrubPreviewArgs {
   videoRef: RefObject<HTMLVideoElement | null>;
@@ -54,6 +65,8 @@ export function useIosScrubPreview({
   const activePreviewFrameSrcRef = useRef<string | null>(null);
   /** The moment the display is trying to represent, wherever the request came from. */
   const previewTargetTimeRef = useRef<number | null>(null);
+  const frameCallbackHandleRef = useRef<number | null>(null);
+  const revealFallbackTimeoutRef = useRef<number | null>(null);
 
   const [scrubPreviewTime, setScrubPreviewTime] = useState<number | null>(null);
   const [pausedPreviewTime, setPausedPreviewTime] = useState<number | null>(
@@ -82,6 +95,47 @@ export function useIosScrubPreview({
     [previewThumbnails],
   );
 
+  const cancelPendingReveal = useCallback(() => {
+    const video = videoRef.current as VideoWithFrameCallback | null;
+    if (frameCallbackHandleRef.current !== null) {
+      video?.cancelVideoFrameCallback?.(frameCallbackHandleRef.current);
+      frameCallbackHandleRef.current = null;
+    }
+    if (revealFallbackTimeoutRef.current !== null) {
+      window.clearTimeout(revealFallbackTimeoutRef.current);
+      revealFallbackTimeoutRef.current = null;
+    }
+  }, [videoRef]);
+
+  /**
+   * Uncover the element once it has actually presented a frame.
+   *
+   * `seeked` only says the seek finished, not that anything has been painted,
+   * and uncovering in that gap is what showed a blank flash before the frame
+   * appeared. `requestVideoFrameCallback` fires on presentation, which is the
+   * event we actually want. A timeout backs it up: on a browser that does not
+   * implement it, or does not fire it for a paused element, the reveal still
+   * happens rather than leaving the thumbnail up for good.
+   */
+  const revealWhenFramePresented = useCallback(() => {
+    cancelPendingReveal();
+
+    const reveal = () => {
+      cancelPendingReveal();
+      setIsPreviewNeeded(false);
+    };
+
+    const video = videoRef.current as VideoWithFrameCallback | null;
+    revealFallbackTimeoutRef.current = window.setTimeout(
+      reveal,
+      PREVIEW_REVEAL_TIMEOUT_MS,
+    );
+
+    if (video && typeof video.requestVideoFrameCallback === "function") {
+      frameCallbackHandleRef.current = video.requestVideoFrameCallback(reveal);
+    }
+  }, [cancelPendingReveal, videoRef]);
+
   /**
    * Ask for the thumbnail to cover a move to `time` — but only when it would be
    * an improvement on what is already displayed.
@@ -94,24 +148,33 @@ export function useIosScrubPreview({
    */
   const requestPreviewFor = useCallback(
     (time: number) => {
+      // Any pending reveal is now stale — the display is being sent somewhere
+      // else, so a frame presented for the previous target must not uncover the
+      // element.
+      cancelPendingReveal();
+
       setIsPreviewNeeded((wasNeeded) => {
         if (wasNeeded) {
           return true;
         }
-        const landed = lastCommittedVideoTimeRef.current;
-        if (landed === null) {
+        // Compared against the element's live position, not a cached one.
+        // `lastCommittedVideoTimeRef` only advances while `scrubPreviewTimeRef`
+        // is null, which is never true mid-scrub or mid-step, so it goes stale
+        // exactly when this comparison matters — drifting past the thumbnail's
+        // error and making the rule flip-flop, which is what flashed the panel
+        // while a step key was held.
+        const landed = videoRef.current?.currentTime;
+        if (landed === undefined) {
           return true;
         }
         const thumbnail = getNearestPreviewThumbnail(time);
         if (!thumbnail) {
           return false;
         }
-        return (
-          Math.abs(thumbnail.timestamp - time) < Math.abs(landed - time)
-        );
+        return Math.abs(thumbnail.timestamp - time) < Math.abs(landed - time);
       });
     },
-    [getNearestPreviewThumbnail],
+    [cancelPendingReveal, getNearestPreviewThumbnail, videoRef],
   );
 
   const activePreviewFrameSrc = useMemo(() => {
@@ -258,7 +321,7 @@ export function useIosScrubPreview({
           Math.abs(video.currentTime - previewTarget) <= PREVIEW_MATCH_TOLERANCE;
 
         if (hasCaughtUp) {
-          setIsPreviewNeeded(false);
+          revealWhenFramePresented();
         }
 
         if (
@@ -285,11 +348,12 @@ export function useIosScrubPreview({
     return () => {
       video.removeEventListener("seeked", syncSeekTime);
     };
-  }, [updateCurrentTime, videoRef]);
+  }, [revealWhenFramePresented, updateCurrentTime, videoRef]);
 
   // Cleanup all timers/RAFs on unmount.
   useEffect(() => {
     return () => {
+      cancelPendingReveal();
       if (scrubSeekTimeoutRef.current !== null) {
         window.clearTimeout(scrubSeekTimeoutRef.current);
       }
@@ -300,7 +364,7 @@ export function useIosScrubPreview({
         window.clearTimeout(previewSwapTimeoutRef.current);
       }
     };
-  }, []);
+  }, [cancelPendingReveal]);
 
   // Cross-fade swap between displayed and incoming preview frames.
   useEffect(() => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -10,6 +10,7 @@ import {
 
 
 import {
+  PREVIEW_MATCH_TOLERANCE,
   PREVIEW_SWAP_DELAY_MS,
   PreviewThumbnail,
   SCRUB_SEEK_INTERVAL_MS,
@@ -51,6 +52,8 @@ export function useIosScrubPreview({
   const previewSwapTimeoutRef = useRef<number | null>(null);
   const lastCommittedVideoTimeRef = useRef<number | null>(null);
   const activePreviewFrameSrcRef = useRef<string | null>(null);
+  /** The moment the display is trying to represent, wherever the request came from. */
+  const previewTargetTimeRef = useRef<number | null>(null);
 
   const [scrubPreviewTime, setScrubPreviewTime] = useState<number | null>(null);
   const [pausedPreviewTime, setPausedPreviewTime] = useState<number | null>(
@@ -64,27 +67,68 @@ export function useIosScrubPreview({
   >(null);
   const [isIncomingPreviewVisible, setIsIncomingPreviewVisible] =
     useState(false);
+  /**
+   * Whether the thumbnail is still needed.
+   *
+   * Separate from `scrubPreviewTime`, which is where the *pointer* is and must
+   * keep driving the timeline marker for the whole drag. Conflating the two is
+   * why the thumbnail could not be taken down mid-drag: hiding it meant clearing
+   * the pointer position, which would have snapped the marker backwards.
+   */
+  const [isPreviewNeeded, setIsPreviewNeeded] = useState(false);
 
   const getNearestPreviewThumbnail = useCallback(
     (time: number) => findNearestPreviewThumbnail(previewThumbnails, time),
     [previewThumbnails],
   );
 
+  /**
+   * Ask for the thumbnail to cover a move to `time` — but only when it would be
+   * an improvement on what is already displayed.
+   *
+   * Once the real frame is on screen, a small nudge should keep it: the element
+   * is showing a frame a few hundredths of a second away, while the nearest
+   * thumbnail can be half a second off. Swapping to the thumbnail would be a
+   * downgrade, and doing that on every small movement is what would make the
+   * panel strobe between the two sources.
+   */
+  const requestPreviewFor = useCallback(
+    (time: number) => {
+      setIsPreviewNeeded((wasNeeded) => {
+        if (wasNeeded) {
+          return true;
+        }
+        const landed = lastCommittedVideoTimeRef.current;
+        if (landed === null) {
+          return true;
+        }
+        const thumbnail = getNearestPreviewThumbnail(time);
+        if (!thumbnail) {
+          return false;
+        }
+        return (
+          Math.abs(thumbnail.timestamp - time) < Math.abs(landed - time)
+        );
+      });
+    },
+    [getNearestPreviewThumbnail],
+  );
+
   const activePreviewFrameSrc = useMemo(() => {
+    if (!isPreviewNeeded) {
+      return null;
+    }
     const sourceTime = scrubPreviewTime ?? pausedPreviewTime;
-    const selected =
-      sourceTime !== null ? getNearestPreviewThumbnail(sourceTime) : null;
-
-    if (scrubPreviewTime !== null) {
-      return selected?.src ?? null;
+    if (sourceTime === null) {
+      return null;
     }
-
-    if (pausedPreviewTime !== null) {
-      return selected?.src ?? null;
-    }
-
-    return null;
-  }, [getNearestPreviewThumbnail, pausedPreviewTime, scrubPreviewTime]);
+    return getNearestPreviewThumbnail(sourceTime)?.src ?? null;
+  }, [
+    getNearestPreviewThumbnail,
+    isPreviewNeeded,
+    pausedPreviewTime,
+    scrubPreviewTime,
+  ]);
 
   const displayedTimelineTime = scrubPreviewTime ?? currentTime;
   const hasPreviewOverlay =
@@ -96,6 +140,7 @@ export function useIosScrubPreview({
 
   // Reset all preview frame state. Used by bootstrap on video reload and live-photo start.
   const resetPreviewFrames = useCallback(() => {
+    setIsPreviewNeeded(false);
     setDisplayedPreviewFrameSrc(null);
     setIncomingPreviewFrameSrc(null);
     setIsIncomingPreviewVisible(false);
@@ -116,8 +161,10 @@ export function useIosScrubPreview({
       pendingScrubDisplayTimeRef.current = null;
       isScrubPreviewActiveRef.current = false;
       scrubPreviewTimeRef.current = null;
+      previewTargetTimeRef.current = null;
       setScrubPreviewTime(null);
       setPausedPreviewTime(null);
+      setIsPreviewNeeded(false);
       setDisplayedPreviewFrameSrc(null);
       setIncomingPreviewFrameSrc(null);
       setIsIncomingPreviewVisible(false);
@@ -195,6 +242,23 @@ export function useIosScrubPreview({
         if (hasPlayheadSettled && scrubPreviewTimeRef.current !== null) {
           scrubPreviewTimeRef.current = null;
           setScrubPreviewTime(null);
+        }
+
+        // Mid-drag reveal. Nothing further is queued, so this frame is where the
+        // pointer is pointing — and the real element is showing it, while the
+        // thumbnail is a nearest-neighbour guess up to half a second away.
+        // Holding still during a drag now shows the truth rather than saving it
+        // for mouse-up, which is what made the picture change under the worker
+        // just as they decided what to capture.
+        const previewTarget = previewTargetTimeRef.current;
+        const hasCaughtUp =
+          scrubQueuedSeekTimeRef.current === null &&
+          scrubSeekTimeoutRef.current === null &&
+          previewTarget !== null &&
+          Math.abs(video.currentTime - previewTarget) <= PREVIEW_MATCH_TOLERANCE;
+
+        if (hasCaughtUp) {
+          setIsPreviewNeeded(false);
         }
 
         if (
@@ -321,6 +385,8 @@ export function useIosScrubPreview({
       const video = videoRef.current;
       if (!video) return;
       video.pause();
+      previewTargetTimeRef.current = t;
+      requestPreviewFor(t);
       if (scrubPreviewTimeRef.current === null) {
         setPausedPreviewTime(t);
       }
@@ -337,6 +403,7 @@ export function useIosScrubPreview({
     },
     [
       livePhotoEndRef,
+      requestPreviewFor,
       setIsLivePhotoActive,
       syncFocusToTimestamp,
       updateCurrentTime,
@@ -398,6 +465,10 @@ export function useIosScrubPreview({
     scrubDisplayRafRef.current = null;
     const nextTime = pendingScrubDisplayTimeRef.current;
     scrubPreviewTimeRef.current = nextTime;
+    previewTargetTimeRef.current = nextTime;
+    if (nextTime !== null) {
+      requestPreviewFor(nextTime);
+    }
     setScrubPreviewTime(nextTime);
 
     if (nextTime === null || !isScrubPreviewActiveRef.current) {
@@ -405,7 +476,7 @@ export function useIosScrubPreview({
     }
 
     scheduleScrubSeek(nextTime, false, false);
-  }, [scheduleScrubSeek]);
+  }, [requestPreviewFor, scheduleScrubSeek]);
 
   const scheduleScrubDisplayTime = useCallback(
     (time: number | null, immediate: boolean = false) => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-step-hotkeys.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-step-hotkeys.ts
@@ -13,6 +13,7 @@ interface UseIosStepHotkeysArgs {
   ) => void;
   handleScrubCommit: (time: number) => void;
   setPausedPreviewTime: (time: number | null) => void;
+  onScrubActiveChange: (active: boolean) => void;
 }
 
 /**
@@ -28,11 +29,34 @@ export function useIosStepHotkeys({
   scheduleScrubSeek,
   handleScrubCommit,
   setPausedPreviewTime,
+  onScrubActiveChange,
 }: UseIosStepHotkeysArgs) {
   const stepCommitTimeoutRef = useRef<number | null>(null);
   const steppedTargetTimeRef = useRef<number | null>(null);
+  const isSteppingRef = useRef(false);
 
   useEffect(() => {
+    // Holding a step key is scrubbing by keyboard, so it reports itself as an
+    // active scrub for the duration. Without that, each throttled seek landed
+    // with nothing queued behind it, which reads as "the playhead has settled" —
+    // so the preview was torn down and rebuilt on every repeat, flashing the
+    // video element in and out for as long as the key was held.
+    const beginStepping = () => {
+      if (isSteppingRef.current) {
+        return;
+      }
+      isSteppingRef.current = true;
+      onScrubActiveChange(true);
+    };
+
+    const endStepping = () => {
+      if (!isSteppingRef.current) {
+        return;
+      }
+      isSteppingRef.current = false;
+      onScrubActiveChange(false);
+    };
+
     const flushSteppedTarget = () => {
       if (steppedTargetTimeRef.current === null) {
         return;
@@ -49,6 +73,8 @@ export function useIosStepHotkeys({
       stepCommitTimeoutRef.current = window.setTimeout(() => {
         stepCommitTimeoutRef.current = null;
         flushSteppedTarget();
+        // Idle long enough to count as released, so the reveal can happen.
+        endStepping();
       }, STEP_COMMIT_DELAY_MS);
     };
 
@@ -72,6 +98,7 @@ export function useIosStepHotkeys({
       }
 
       event.preventDefault();
+      beginStepping();
       const delta = event.key === "," ? -FRAME_STEP_SECONDS : FRAME_STEP_SECONDS;
       const baseTime =
         steppedTargetTimeRef.current ??
@@ -96,6 +123,7 @@ export function useIosStepHotkeys({
         stepCommitTimeoutRef.current = null;
       }
       flushSteppedTarget();
+      endStepping();
     };
 
     window.addEventListener("keydown", handleFrameStepKeydown);
@@ -107,6 +135,7 @@ export function useIosStepHotkeys({
   }, [
     currentTimeRef,
     handleScrubCommit,
+    onScrubActiveChange,
     scheduleScrubDisplayTime,
     scheduleScrubSeek,
     scrubPreviewTimeRef,

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
@@ -5,6 +5,7 @@ import { UseFormSetValue } from "react-hook-form";
 import { FrameData, TraceFormData } from "../../../types";
 import { DraftFetchResults } from "../../../../util";
 import { extractThumbnails, extractVideoFrame } from "../../util";
+import { recordPhase } from "./scrub-profiler";
 import {
   MAX_TIMELINE_THUMBS,
   PREVIEW_THUMB_HEIGHT,
@@ -93,6 +94,7 @@ export function useIosVideoBootstrap({
       if (draftFetchResult === DraftFetchResults.LOADING) {
         return;
       }
+      const bootstrapStartedAt = performance.now();
       try {
         isProcessingRef.current = true;
         setIsVideoReady(false);
@@ -136,6 +138,7 @@ export function useIosVideoBootstrap({
         if (video.duration === 0) {
           throw new Error("Video duration not available");
         }
+        const timelineThumbsStartedAt = performance.now();
         const thumbs = await extractThumbnails(
           video,
           video.duration,
@@ -148,10 +151,13 @@ export function useIosVideoBootstrap({
             preferOffscreenCanvas: true,
           },
         );
+        recordPhase("timelineThumbnails", performance.now() - timelineThumbsStartedAt);
         thumbnailObjectUrlsRef.current = thumbs
           .map((thumb) => thumb.src)
           .filter((src) => src.startsWith("blob:"));
         setThumbnails(thumbs);
+        // The phase that disappears if the preview pipeline is removed.
+        const previewThumbsStartedAt = performance.now();
         const largePreviewThumbs = await extractThumbnails(
           video,
           video.duration,
@@ -164,6 +170,11 @@ export function useIosVideoBootstrap({
             preferOffscreenCanvas: true,
           },
         );
+        recordPhase(
+          "previewThumbnails",
+          performance.now() - previewThumbsStartedAt,
+        );
+        recordPhase("previewThumbnailCount", largePreviewThumbs.length);
         previewThumbnailObjectUrlsRef.current = largePreviewThumbs
           .map((thumb) => thumb.src)
           .filter((src) => src.startsWith("blob:"));
@@ -203,6 +214,7 @@ export function useIosVideoBootstrap({
           "screens",
           draftScreens.sort((a, b) => a.timestamp - b.timestamp),
         );
+        recordPhase("bootstrapTotal", performance.now() - bootstrapStartedAt);
         // Done seeking the live element. Anything holding a playhead position
         // can place it now without bootstrap dragging it away.
         setIsVideoReady(true);

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
@@ -58,6 +58,11 @@ export function useIosVideoBootstrap({
   const thumbnailObjectUrlsRef = useRef<string[]>([]);
   const previewThumbnailObjectUrlsRef = useRef<string[]>([]);
   const isProcessingRef = useRef(false);
+  /**
+   * Identifies the current bootstrap run, so work deferred past the interactive
+   * phase can tell whether it is still wanted.
+   */
+  const bootstrapRunIdRef = useRef(0);
 
   const [videoDuration, setVideoDuration] = useState(0);
   const [isVideoReady, setIsVideoReady] = useState(false);
@@ -84,6 +89,7 @@ export function useIosVideoBootstrap({
   // Bootstrap effect: load the video, extract thumbnails + preview thumbnails,
   // and populate any screens missing a frame image.
   useEffect(() => {
+    const runId = bootstrapRunIdRef.current;
     const loadVideoAndPopulate = async () => {
       if (isProcessingRef.current) {
         return;
@@ -95,6 +101,9 @@ export function useIosVideoBootstrap({
         return;
       }
       const bootstrapStartedAt = performance.now();
+      // Captured for the deferred phase below, which runs outside the try block.
+      let video: HTMLVideoElement;
+      let duration: number;
       try {
         isProcessingRef.current = true;
         setIsVideoReady(false);
@@ -105,7 +114,7 @@ export function useIosVideoBootstrap({
         setThumbnails([]);
         setPreviewThumbnails([]);
         onResetPreviewFrames();
-        const video = videoRef.current;
+        video = videoRef.current;
         video.src = videoFiles[0].fileUrl;
         await new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => {
@@ -138,6 +147,7 @@ export function useIosVideoBootstrap({
         if (video.duration === 0) {
           throw new Error("Video duration not available");
         }
+        duration = video.duration;
         const timelineThumbsStartedAt = performance.now();
         const thumbs = await extractThumbnails(
           video,
@@ -156,29 +166,6 @@ export function useIosVideoBootstrap({
           .map((thumb) => thumb.src)
           .filter((src) => src.startsWith("blob:"));
         setThumbnails(thumbs);
-        // The phase that disappears if the preview pipeline is removed.
-        const previewThumbsStartedAt = performance.now();
-        const largePreviewThumbs = await extractThumbnails(
-          video,
-          video.duration,
-          Math.min(90, Math.max(52, Math.ceil(video.duration))),
-          PREVIEW_THUMB_HEIGHT,
-          {
-            mimeType: "image/jpeg",
-            quality: PREVIEW_THUMB_JPEG_QUALITY,
-            output: "object-url",
-            preferOffscreenCanvas: true,
-          },
-        );
-        recordPhase(
-          "previewThumbnails",
-          performance.now() - previewThumbsStartedAt,
-        );
-        recordPhase("previewThumbnailCount", largePreviewThumbs.length);
-        previewThumbnailObjectUrlsRef.current = largePreviewThumbs
-          .map((thumb) => thumb.src)
-          .filter((src) => src.startsWith("blob:"));
-        setPreviewThumbnails(largePreviewThumbs);
         const screensSnapshot = screensRef.current.map((screen) => ({
           ...screen,
         }));
@@ -221,11 +208,64 @@ export function useIosVideoBootstrap({
       } catch (e) {
         console.error("Error loading video blob:", e);
         toast.error("Error loading video for frame extraction");
+        return;
       } finally {
         isProcessingRef.current = false;
       }
+
+      // Scrub-preview thumbnails, deliberately after the step is interactive.
+      //
+      // Nothing on screen needs them: with an empty grid the preview overlay
+      // never renders and scrubbing falls through to real video frames, which
+      // measured at 14-38ms median across Chrome and Safari. Blocking on this
+      // was between a third and a half of the wait to enter the step.
+      //
+      // Extraction runs on its own cloned element, so it cannot disturb the
+      // playhead — but it does compete for decode bandwidth, so seeks in the
+      // first seconds may be slower than once it has finished.
+      if (bootstrapRunIdRef.current !== runId) {
+        return;
+      }
+      try {
+        const previewThumbsStartedAt = performance.now();
+        const largePreviewThumbs = await extractThumbnails(
+          video,
+          duration,
+          Math.min(90, Math.max(52, Math.ceil(duration))),
+          PREVIEW_THUMB_HEIGHT,
+          {
+            mimeType: "image/jpeg",
+            quality: PREVIEW_THUMB_JPEG_QUALITY,
+            output: "object-url",
+            preferOffscreenCanvas: true,
+          },
+        );
+        // The worker may have left the step while this ran. Its blob URLs are
+        // not in the ref yet, so the unmount sweep cannot see them.
+        if (bootstrapRunIdRef.current !== runId) {
+          revokeBlobUrls(largePreviewThumbs.map((thumb) => thumb.src));
+          return;
+        }
+        recordPhase(
+          "previewThumbnails",
+          performance.now() - previewThumbsStartedAt,
+        );
+        recordPhase("previewThumbnailCount", largePreviewThumbs.length);
+        previewThumbnailObjectUrlsRef.current = largePreviewThumbs
+          .map((thumb) => thumb.src)
+          .filter((src) => src.startsWith("blob:"));
+        setPreviewThumbnails(largePreviewThumbs);
+      } catch (error) {
+        // Scrubbing keeps working on real frames, so this is not worth a toast.
+        console.error(`Error extracting scrub preview thumbnails: ${error}`);
+      }
     };
     loadVideoAndPopulate();
+    return () => {
+      // Invalidate the run so deferred extraction stops and cleans up after
+      // itself if the worker leaves the step.
+      bootstrapRunIdRef.current += 1;
+    };
   }, [
     draftFetchResult,
     onResetPreviewFrames,

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
@@ -256,8 +256,13 @@ export function useIosVideoBootstrap({
           .filter((src) => src.startsWith("blob:"));
         setPreviewThumbnails(largePreviewThumbs);
       } catch (error) {
-        // Scrubbing keeps working on real frames, so this is not worth a toast.
+        // Worth a toast after all. The previous note here reasoned that scrubbing
+        // still falls back to real frames, which is true — but the worker loses
+        // every preview during a drag and is given no reason for it. That state
+        // had to be diagnosed from behaviour once already, because a console
+        // error is silence to anyone not holding devtools open.
         console.error(`Error extracting scrub preview thumbnails: ${error}`);
+        toast.error("Scrub previews unavailable — scrubbing still works");
       }
     };
     loadVideoAndPopulate();

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/video-preview-overlay.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/video-preview-overlay.tsx
@@ -25,14 +25,18 @@ export function VideoPreviewOverlay({
 }: VideoPreviewOverlayProps) {
   return (
     <div className="relative flex justify-center items-center w-full h-full">
+      {/*
+        Always painted. The preview images stack on top and cover it, so hiding
+        it was never necessary — and toggling opacity on a video forces a
+        compositor layer change, which showed up as a blip each time the overlay
+        came down. Leaving it composited means uncovering it is just the image
+        above it going away.
+      */}
       <video
         ref={videoRef}
         crossOrigin="anonymous"
         preload="auto"
-        className={cn(
-          "relative z-0 max-w-full max-h-full rounded-lg object-contain transition-opacity",
-          hasPreviewOverlay ? "opacity-0" : "opacity-100",
-        )}
+        className="relative z-0 max-w-full max-h-full rounded-lg object-contain"
         controls={false}
         onPlay={onPlay}
         onPause={onPause}

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
@@ -16,10 +16,9 @@ import { FrameData, TraceFormData } from "../types";
 import { useHotkeys } from "react-hotkeys-hook";
 import { RepairScreenAndroid } from "./components/android/repair-screen-android";
 import { RepairScreenIOS } from "./components/ios/repair-screen-ios";
-import { Prisma, ScreenGesture } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { DraftFetchResults } from "../../util";
 import { ListedFiles } from "@/lib/actions";
-import { validateGestureDescription } from "./util";
 
 export interface RepairScreenJumpTarget {
   nonce: number;
@@ -32,6 +31,46 @@ export interface RepairScreenJumpTarget {
  */
 const EMPTY_SCREENS: FrameData[] = [];
 
+/**
+ * What caused a screen to be selected. Determines whether the recording follows,
+ * so that policy lives in one readable place instead of being spread across call
+ * sites — which is how the filmstrip ended up seeking one way and the feedback
+ * checklist another.
+ */
+export type SelectScreenSource =
+  /** A feedback checklist chip. Explicitly "take me to this screen". */
+  | "jump"
+  /** A click on a filmstrip thumbnail. Also explicit. */
+  | "filmstrip"
+  /** Tab or the arrow keys, stepping through screens while annotating. */
+  | "keyboard"
+  /** A frame the worker just captured. */
+  | "capture"
+  /** The selected screen was removed, so nothing is selected. */
+  | "delete"
+  /** Derived from the playhead — the recording moved first, so it must not move again. */
+  | "playhead";
+
+/**
+ * Sources that carry the recording to the selected screen.
+ *
+ * Deliberately excludes `keyboard`: workers tab through screens quickly while
+ * annotating, and seeking on every step would churn the video and its preview
+ * frames. Excludes `capture` because the playhead is already there, and
+ * `playhead` because that selection came *from* the recording — moving it again
+ * is the feedback loop that let a click land on a neighbouring screen.
+ */
+const SOURCES_THAT_MOVE_PLAYHEAD: ReadonlySet<SelectScreenSource> = new Set([
+  "jump",
+  "filmstrip",
+]);
+
+/** A request to place the recording's playhead, applied once per nonce. */
+export interface PlayheadRequest {
+  time: number;
+  nonce: number;
+}
+
 interface NavigationContextType {
   handleNext: () => void;
   handlePrevious: () => void;
@@ -41,7 +80,11 @@ interface NavigationContextType {
    * a screen shifts positions, so an index cannot survive an edit to the trace.
    */
   focusedScreenId: string | null;
-  setFocusedScreenId: (screenId: string | null) => void;
+  /**
+   * Focus a screen, declaring why. The reason decides whether the recording
+   * follows; see `SOURCES_THAT_MOVE_PLAYHEAD`.
+   */
+  selectScreen: (screenId: string | null, source: SelectScreenSource) => void;
   /**
    * Position of the focused screen in the sorted list, derived from
    * `focusedScreenId`. Provided here so ordering questions ("is this the last
@@ -50,11 +93,14 @@ interface NavigationContextType {
    */
   focusedIndex: number;
   /**
-   * Lets a platform with a scrubbable recording hand up a seek function, so an
-   * explicit jump to a screen can move the playhead with it. Pass `null` to
-   * unregister. Android has no recording to scrub and never registers.
+   * Where the recording has been asked to sit, or `null` if nothing has asked.
+   *
+   * Desired state rather than an imperative call: a platform that owns a
+   * recording reconciles towards it whenever it is able to, so a request made
+   * while the video is still loading is applied when loading finishes instead of
+   * being lost. Platforms without a recording ignore it.
    */
-  registerSeekToTime: (seek: ((timestamp: number) => void) | null) => void;
+  playheadRequest: PlayheadRequest | null;
 }
 
 const NavigationContext = createContext<NavigationContextType | undefined>(
@@ -108,6 +154,9 @@ export default function RepairScreen({
 
   const os = capture?.task ? capture.task.os : "none";
   const [focusedScreenId, setFocusedScreenId] = useState<string | null>(null);
+  const [playheadRequest, setPlayheadRequest] =
+    useState<PlayheadRequest | null>(null);
+  const playheadNonceRef = useRef(0);
   const focusedIndex = useMemo(
     () =>
       focusedScreenId === null
@@ -116,14 +165,31 @@ export default function RepairScreen({
     [focusedScreenId, screens],
   );
 
-  // Held in a ref rather than state: registering a seek function must not
-  // re-render, and the jump effect only ever reads the current one.
-  const seekToTimeRef = useRef<((timestamp: number) => void) | null>(null);
-  const registerSeekToTime = useCallback(
-    (seek: ((timestamp: number) => void) | null) => {
-      seekToTimeRef.current = seek;
+  /**
+   * Every selection goes through here, so "does the recording follow?" is
+   * answered once, from the reason, rather than at each call site.
+   */
+  const selectScreen = useCallback(
+    (screenId: string | null, source: SelectScreenSource) => {
+      setFocusedScreenId(screenId);
+
+      if (screenId === null || !SOURCES_THAT_MOVE_PLAYHEAD.has(source)) {
+        return;
+      }
+      const screen = screens.find((candidate) => candidate.id === screenId);
+      if (!screen) {
+        return;
+      }
+      // A nonce rather than the timestamp alone: re-selecting the same screen has
+      // to re-place the playhead, and the value has to differ for the reconciler
+      // to notice.
+      playheadNonceRef.current += 1;
+      setPlayheadRequest({
+        time: screen.timestamp,
+        nonce: playheadNonceRef.current,
+      });
     },
-    [],
+    [screens],
   );
 
   // Navigation is deliberately unguarded. Gesture completeness is enforced
@@ -145,8 +211,8 @@ export default function RepairScreen({
     if (wrappedIndex < 0) {
       wrappedIndex = screens.length - 1;
     }
-    setFocusedScreenId(screens[wrappedIndex].id);
-  }, [focusedIndex, screens]);
+    selectScreen(screens[wrappedIndex].id, "keyboard");
+  }, [focusedIndex, screens, selectScreen]);
 
   // handle focusing on next screen in the filmstrip list
   const handleNext = useCallback(() => {
@@ -154,8 +220,8 @@ export default function RepairScreen({
       return;
     }
     const wrappedIndex = (focusedIndex + 1) % screens.length;
-    setFocusedScreenId(screens[wrappedIndex].id);
-  }, [focusedIndex, screens]);
+    selectScreen(screens[wrappedIndex].id, "keyboard");
+  }, [focusedIndex, screens, selectScreen]);
 
   const handleDeleteScreen = useCallback(
     (screenId: string) => {
@@ -189,9 +255,9 @@ export default function RepairScreen({
       setValue("gestures", nextGestures);
       setValue("redactions", nextRedactions);
       setValue("vhs", nextVHs);
-      setFocusedScreenId(null);
+      selectScreen(null, "delete");
     },
-    [getValues, setValue],
+    [getValues, selectScreen, setValue],
   );
 
   useHotkeys(
@@ -255,19 +321,17 @@ export default function RepairScreen({
       return;
     }
 
-    const targetIndex = screens.findIndex(
+    const targetScreen = screens.find(
       (screen) => screen.id === jumpTarget.screenId,
     );
-    if (targetIndex >= 0) {
+    if (targetScreen) {
       appliedJumpNonceRef.current = jumpTarget.nonce;
-      setFocusedScreenId(jumpTarget.screenId);
-      // Move the recording to the same screen, matching what clicking the
-      // filmstrip already does. Without this the playhead stays where it was,
-      // and `c` would capture a frame from an unrelated part of the video —
-      // which is exactly what the feedback often asks the worker to do.
-      seekToTimeRef.current?.(screens[targetIndex].timestamp);
+      // "jump" carries the recording with it, so the worker lands on the screen
+      // *and* the moment it came from — `c` would otherwise capture a frame from
+      // wherever the playhead was left.
+      selectScreen(targetScreen.id, "jump");
     }
-  }, [jumpTarget, screens]);
+  }, [jumpTarget, screens, selectScreen]);
 
   return (
     <NavigationProvider
@@ -276,9 +340,9 @@ export default function RepairScreen({
         handlePrevious,
         handleDeleteScreen,
         focusedScreenId,
-        setFocusedScreenId,
+        selectScreen,
         focusedIndex,
-        registerSeekToTime,
+        playheadRequest,
       }}
     >
       {(os.toLowerCase() as Platform) === Platform.ANDROID ? (

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
@@ -39,22 +39,81 @@ const resolveExtractOptions = (
   };
 };
 
+/**
+ * How long to wait for a seek to report back before drawing anyway.
+ *
+ * Asking for the position the element already holds may complete without firing
+ * `seeked` at all, and an unbounded wait there hangs the caller for good —
+ * capturing at the current playhead is exactly that case. Falling through is safe
+ * precisely when it happens, because the frame on the element is already the one
+ * being asked for.
+ *
+ * Deliberately a deadline rather than a `video.seeking` check. Skipping the wait
+ * whenever `seeking` reads false would draw before the frame arrives on any engine
+ * that sets the flag asynchronously, which trades a hang for a wrong frame — the
+ * far worse of the two, and the failure this whole area has already been bitten by.
+ */
+const SEEK_SETTLE_TIMEOUT_MS = 500;
+
+/** Deadline for a thumbnail element to report metadata before giving up on it. */
+const THUMBNAIL_VIDEO_LOAD_TIMEOUT_MS = 20000;
+
 const seekVideoToTime = async (video: HTMLVideoElement, t: number) => {
   await new Promise<void>((resolve, reject) => {
-    const onSeeked = () => {
+    let timeout: number | null = null;
+    const cleanup = () => {
+      if (timeout !== null) {
+        clearTimeout(timeout);
+      }
       video.removeEventListener("seeked", onSeeked);
       video.removeEventListener("error", onError);
+    };
+    const onSeeked = () => {
+      cleanup();
       resolve();
     };
     const onError = (e: Event) => {
-      video.removeEventListener("seeked", onSeeked);
-      video.removeEventListener("error", onError);
+      cleanup();
       reject(e);
     };
+    timeout = window.setTimeout(() => {
+      cleanup();
+      resolve();
+    }, SEEK_SETTLE_TIMEOUT_MS);
     video.addEventListener("seeked", onSeeked, { once: true });
     video.addEventListener("error", onError, { once: true });
     video.currentTime = t;
   });
+};
+
+/**
+ * One read at a time per element.
+ *
+ * Two overlapping seeks on one element resolve on each other's `seeked` and leave
+ * the decoder where neither caller asked, so the loser draws the winner's frame.
+ * `extractVideoThumbnails` has always known this — "parallel messes up seeking" —
+ * and runs its own loop sequentially, but the displayed element is read by three
+ * callers that cannot see one another: `c` captures, the bootstrap screen pass,
+ * and the scrub queue moving the playhead underneath both.
+ *
+ * Keyed per element rather than globally, so a capture does not have to queue
+ * behind ninety thumbnail extractions on a different element.
+ */
+const readQueues = new WeakMap<HTMLVideoElement, Promise<unknown>>();
+
+const enqueueRead = <T,>(
+  video: HTMLVideoElement,
+  operation: () => Promise<T>
+): Promise<T> => {
+  const previous = readQueues.get(video) ?? Promise.resolve();
+  const run = previous.then(operation, operation);
+  // Swallowed for the chain's benefit only: a failed read must not block the
+  // reads behind it. The caller still sees the rejection through `run`.
+  readQueues.set(
+    video,
+    run.catch(() => undefined)
+  );
+  return run;
 };
 
 const drawFrameToCanvas = (
@@ -174,7 +233,7 @@ export async function extractVideoFrame(
   overrideOptions?: ExtractVideoFrameOptions
 ): Promise<FrameData> {
   const options = resolveExtractOptions(scaleOrOptions, overrideOptions);
-  return grabFrameViaCanvas(video, t, options);
+  return enqueueRead(video, () => grabFrameViaCanvas(video, t, options));
 }
 
 /**
@@ -195,12 +254,65 @@ export async function extractVideoThumbnails(
   const thumbVideo = document.createElement("video");
   thumbVideo.crossOrigin = "anonymous";
   thumbVideo.preload = "metadata";
-  thumbVideo.src = video.src;
-  await new Promise<void>((res) =>
-    thumbVideo.addEventListener("loadedmetadata", () => res(), {
-      once: true,
-    })
-  );
+  thumbVideo.src = video.currentSrc || video.src;
+  try {
+    // Rejects rather than waiting forever. With no error path and no deadline
+    // this promise could simply never settle — an element that never gets
+    // metadata never fires the event — and the caller was left with an empty
+    // thumbnail grid, no toast, and nothing in the console. A scrub with no
+    // preview and no badge is what that looks like from the outside, and it had
+    // to be diagnosed from behaviour because nothing reported it.
+    await new Promise<void>((resolve, reject) => {
+      let timeout: number | null = null;
+      const cleanup = () => {
+        if (timeout !== null) {
+          clearTimeout(timeout);
+        }
+        thumbVideo.removeEventListener("loadedmetadata", onLoaded);
+        thumbVideo.removeEventListener("error", onError);
+      };
+      const onLoaded = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = () => {
+        cleanup();
+        reject(new Error("Thumbnail video failed to load"));
+      };
+      timeout = window.setTimeout(() => {
+        cleanup();
+        reject(new Error("Thumbnail video load timed out"));
+      }, THUMBNAIL_VIDEO_LOAD_TIMEOUT_MS);
+      thumbVideo.addEventListener("loadedmetadata", onLoaded, { once: true });
+      thumbVideo.addEventListener("error", onError, { once: true });
+    });
+    return await extractThumbnailsFrom(
+      thumbVideo,
+      video,
+      videoDuration,
+      maxThumbs,
+      thumbHeight,
+      options
+    );
+  } finally {
+    // Releases the element's hold on the resource. Whether a detached media
+    // element with a loaded source is collected promptly is engine-dependent, so
+    // this is hygiene rather than a measured fix — but browsers do cap how many
+    // videos they decode at once, and two of these were created per bootstrap
+    // and never let go.
+    thumbVideo.removeAttribute("src");
+    thumbVideo.load();
+  }
+}
+
+async function extractThumbnailsFrom(
+  thumbVideo: HTMLVideoElement,
+  video: HTMLVideoElement,
+  videoDuration: number,
+  maxThumbs: number,
+  thumbHeight: number,
+  options?: ExtractVideoFrameOptions
+): Promise<ListedFiles[]> {
   // determine how many thumbnails to extract
   const duration = videoDuration;
   const fps = 60;

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -297,6 +297,15 @@ export default function Page() {
       const draftFileResponse = await fetch(
         signedLatestDraftFileRes.data.signedUrl,
       );
+      // Checked, because an error response body is not draft JSON and parsing it
+      // throws somewhere far less obvious than here.
+      if (!draftFileResponse.ok) {
+        setDraftFetchResult(DraftFetchResults.ERROR);
+        console.error(
+          `Failed to download draft file: ${draftFileResponse.status}`,
+        );
+        return;
+      }
       const draftFormData: DraftTraceFormData = await draftFileResponse.json();
 
       // Check if we already have screens with src data to avoid overwriting
@@ -338,7 +347,17 @@ export default function Page() {
       }
       setDraftFetchResult(DraftFetchResults.SUCCESS);
     };
-    fetchFiles();
+    // Every early return above reports failure, but a *thrown* failure had
+    // nowhere to go: `fetch` rejects on a network error rather than returning
+    // something falsy, and `.json()` throws on a body that is not JSON. Either
+    // escaped as an unhandled rejection, so the state never left LOADING and the
+    // editor sat on "Loading saved draft data..." for good — with the error state
+    // it needed already built and wired to a message telling the worker what to
+    // do about it.
+    fetchFiles().catch((error) => {
+      setDraftFetchResult(DraftFetchResults.ERROR);
+      console.error(`Failed to load draft data: ${error}`);
+    });
   }, [captureId, draftFetchResult, methods]);
 
   // Fetch video files once when component mounts - files won't change during edit session


### PR DESCRIPTION
  Step 2 of the annotate workspace state reorg, plus fixes found alongside it.

  - One owner for selection and the playhead; playhead moves become requested
    state rather than something several hooks each nudge (`de5890f`)
  - The real frame now appears while a drag is held still, instead of waiting
    for mouse-up (`97cca47`)
  - No video flash while a step key is held, or when the real frame is
    uncovered (`fd70140`, `c1d2da3`)
  - Bootstrap no longer blocks the step on scrub-preview extraction: ~6.8s to
    ~3.6s to become interactive (`7c4035d`)
  - Frame reads are serialized per element, seeks are bounded, and thumbnail
    extraction reports failure instead of hanging silently (`27f021d`)
  - A failed draft load reports itself instead of sitting on
    "Loading saved draft data..." for good (`58a8659`)

  Includes a flag-gated scrub profiler (`19a31ec`, `2949a8c`), off unless
  enabled with `?scrubProfiling=1`.

  QA'd on Chrome: no regressions, and the two new failure paths verified by
  blocking the domain in devtools.

  Known and not addressed here: the settled frame can still be wrong on Safari
  (WebKit 153588, open since 2016). Investigation, evidence and a validated
  ffmpeg.wasm replacement path are on the `safari-frame-investigation` branch
  under `docs/investigations/`.