### PR TITLE
annotate seek deadline

### DIFF
--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -6,6 +6,7 @@ import {
 import { Filmstrip } from "../filmstrip";
 import FrameTimeline from "./extract-frames-timeline";
 import { useHotkeys } from "react-hotkeys-hook";
+import { toast } from "sonner";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { extractVideoFrame, useFormFieldKeyPressGuard } from "../../util";
 import { FrameData, Redaction, TraceFormData } from "../../../types";
@@ -192,11 +193,22 @@ export function RepairScreenIOS({
 
   const handleCaptureFrame = useCallback(async () => {
     if (!videoRef.current) return;
-    const f = await extractVideoFrame(videoRef.current, currentTime, {
-      mimeType: "image/png",
-      output: "object-url",
-      preferOffscreenCanvas: true,
-    });
+    let f: FrameData;
+    try {
+      f = await extractVideoFrame(videoRef.current, currentTime, {
+        mimeType: "image/png",
+        output: "object-url",
+        preferOffscreenCanvas: true,
+      });
+    } catch (error) {
+      // A read can now fail rather than guess: a seek that never completes
+      // rejects instead of drawing whatever frame the element still holds.
+      // Without this the rejection was unhandled and `c` simply did nothing,
+      // which is indistinguishable from a missed keypress.
+      console.error(`Could not capture the current frame: ${error}`);
+      toast.error("Could not capture this frame. Try again.");
+      return;
+    }
     registerScreenUrl(f.src);
     setValue(
       "screens",

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
@@ -171,6 +171,16 @@ export function useIosVideoBootstrap({
         }));
         const draftScreens: FrameData[] = [];
 
+        // Every failure below is contained to the one frame it affects, and the
+        // screen is kept either way.
+        //
+        // This used to be a single try around the whole loop, with the list
+        // written to form state afterwards — so one failed read left the list
+        // truncated at that screen, and a failed warm-up left it empty. Autosave
+        // runs every three minutes and writes form state without checking it, so
+        // the truncated list would go over the worker's draft and take the rest
+        // of their annotation work with it, reporting "Draft autosaved" while
+        // doing so.
         try {
           // Warm the video decoder once before extracting any missing frames.
           const warmupFrame = await extractVideoFrame(video, 0.1, {
@@ -181,8 +191,16 @@ export function useIosVideoBootstrap({
           if (warmupFrame.src.startsWith("blob:")) {
             URL.revokeObjectURL(warmupFrame.src);
           }
-          for (const screen of screensSnapshot) {
-            if (!screen.src) {
+        } catch (error) {
+          // Only a warm-up. The reads below may still succeed, and none of this
+          // is worth a screen.
+          console.error(`Could not warm the video decoder: ${error}`);
+        }
+
+        let unrebuiltScreenCount = 0;
+        for (const screen of screensSnapshot) {
+          if (!screen.src) {
+            try {
               const frame = await extractVideoFrame(video, screen.timestamp, {
                 mimeType: "image/png",
                 output: "object-url",
@@ -190,11 +208,23 @@ export function useIosVideoBootstrap({
               });
               screen.src = frame.src;
               registerScreenUrl(frame.src);
+            } catch (error) {
+              // Keep the screen regardless. Its timestamp is the record of where
+              // the worker marked something, and its id keys the gestures and
+              // redactions they have already written — dropping it discards all
+              // of that to save an image that can be re-extracted.
+              unrebuiltScreenCount += 1;
+              console.error(
+                `Could not rebuild the image for screen ${screen.id}: ${error}`,
+              );
             }
-            draftScreens.push(screen);
           }
-        } catch (error) {
-          console.error(`Error extracting video frames: ${error}`);
+          draftScreens.push(screen);
+        }
+        if (unrebuiltScreenCount > 0) {
+          toast.error(
+            `${unrebuiltScreenCount} of ${screensSnapshot.length} screens could not be rebuilt from the recording. Their annotations are intact.`,
+          );
         }
 
         setValue(

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
@@ -40,20 +40,34 @@ const resolveExtractOptions = (
 };
 
 /**
- * How long to wait for a seek to report back before drawing anyway.
+ * How often to check whether a seek that has not reported back is real.
  *
  * Asking for the position the element already holds may complete without firing
  * `seeked` at all, and an unbounded wait there hangs the caller for good —
- * capturing at the current playhead is exactly that case. Falling through is safe
- * precisely when it happens, because the frame on the element is already the one
- * being asked for.
+ * capturing at the current playhead is exactly that case.
  *
- * Deliberately a deadline rather than a `video.seeking` check. Skipping the wait
- * whenever `seeking` reads false would draw before the frame arrives on any engine
- * that sets the flag asynchronously, which trades a hang for a wrong frame — the
- * far worse of the two, and the failure this whole area has already been bitten by.
+ * The check is `video.seeking`, but taken at this interval rather than
+ * immediately. Read at once it is worthless — engines may not have set the flag
+ * yet — while a seek still in flight half a second later has certainly set it. So
+ * a set flag means "keep waiting, the frame is coming" and a clear one means
+ * "nothing is coming, what is on the element is already the answer".
+ *
+ * The earlier version of this resolved unconditionally at the deadline, which
+ * turned a slow seek into a frame drawn before it arrived: the right timestamp
+ * with the previous picture. That is the failure this whole area has been bitten
+ * by repeatedly, and a busy decoder makes it reachable — screens are extracted
+ * immediately after 35 timeline thumbnails.
  */
-const SEEK_SETTLE_TIMEOUT_MS = 500;
+const SEEK_POLL_INTERVAL_MS = 500;
+
+/**
+ * Absolute cap on waiting for one seek.
+ *
+ * Rejects rather than drawing. Ten seconds of a seek not completing is a real
+ * failure, and guessing at the frame is how a wrong image ends up in a trace
+ * under a plausible timestamp — which reviewers then judge. Callers report it.
+ */
+const SEEK_ABSOLUTE_TIMEOUT_MS = 10000;
 
 /** Deadline for a thumbnail element to report metadata before giving up on it. */
 const THUMBNAIL_VIDEO_LOAD_TIMEOUT_MS = 20000;
@@ -76,10 +90,25 @@ const seekVideoToTime = async (video: HTMLVideoElement, t: number) => {
       cleanup();
       reject(e);
     };
-    timeout = window.setTimeout(() => {
+    const startedAt = performance.now();
+    const check = () => {
+      const waited = performance.now() - startedAt;
+      if (video.seeking && waited < SEEK_ABSOLUTE_TIMEOUT_MS) {
+        // A real seek is in flight. Resolving now would draw the frame it is
+        // replacing.
+        timeout = window.setTimeout(check, SEEK_POLL_INTERVAL_MS);
+        return;
+      }
       cleanup();
+      if (video.seeking) {
+        reject(
+          new Error(`Seek to ${t}s did not complete within ${waited | 0}ms`),
+        );
+        return;
+      }
       resolve();
-    }, SEEK_SETTLE_TIMEOUT_MS);
+    };
+    timeout = window.setTimeout(check, SEEK_POLL_INTERVAL_MS);
     video.addEventListener("seeked", onSeeked, { once: true });
     video.addEventListener("error", onError, { once: true });
     video.currentTime = t;

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
@@ -69,10 +69,41 @@ const SEEK_POLL_INTERVAL_MS = 500;
  */
 const SEEK_ABSOLUTE_TIMEOUT_MS = 10000;
 
+/**
+ * How far the element may sit from the requested moment and still count as the
+ * frame that was asked for. Roughly two frames at 30fps, which covers the snap to
+ * the nearest decodable frame.
+ */
+const SUPERSEDED_SEEK_TOLERANCE_SEC = 2 / 30;
+
 /** Deadline for a thumbnail element to report metadata before giving up on it. */
 const THUMBNAIL_VIDEO_LOAD_TIMEOUT_MS = 20000;
 
+/**
+ * Close enough to skip seeking altogether: the caller is asking for the position
+ * the element is already at. Deliberately far tighter than the superseded
+ * tolerance, which has to absorb frame snapping — this one must only fire when the
+ * request is genuinely the current position, so it never trades frame accuracy for
+ * speed.
+ */
+const ALREADY_AT_POSITION_SEC = 0.001;
+
 const seekVideoToTime = async (video: HTMLVideoElement, t: number) => {
+  // Nothing to wait for. `seeking` is checked because a seek already in flight
+  // means `currentTime` is somebody else's request, not where the element is —
+  // and that flag was set when their seek started, so reading it now is sound in
+  // a way that reading it straight after our own assignment would not be.
+  //
+  // Worth the special case: pressing `c` asks for exactly the current playhead,
+  // no seek starts, no `seeked` is ever coming, and without this the capture waits
+  // out the full poll interval before drawing a frame that was ready immediately.
+  if (
+    !video.seeking &&
+    Math.abs(video.currentTime - t) <= ALREADY_AT_POSITION_SEC
+  ) {
+    return;
+  }
+
   await new Promise<void>((resolve, reject) => {
     let timeout: number | null = null;
     const cleanup = () => {
@@ -121,9 +152,13 @@ const seekVideoToTime = async (video: HTMLVideoElement, t: number) => {
  * Two overlapping seeks on one element resolve on each other's `seeked` and leave
  * the decoder where neither caller asked, so the loser draws the winner's frame.
  * `extractVideoThumbnails` has always known this — "parallel messes up seeking" —
- * and runs its own loop sequentially, but the displayed element is read by three
- * callers that cannot see one another: `c` captures, the bootstrap screen pass,
- * and the scrub queue moving the playhead underneath both.
+ * and runs its own loop sequentially, but the displayed element is read by two
+ * callers that cannot see one another: `c` captures and the bootstrap screen pass.
+ *
+ * It does NOT cover the scrub queue, which writes `video.currentTime` directly and
+ * never comes through here. A drag can therefore retarget the element mid-read;
+ * `grabFrameViaCanvas` catches that afterwards by checking where the element
+ * actually ended up, rather than pretending this lock is enough.
  *
  * Keyed per element rather than globally, so a capture does not have to queue
  * behind ninety thumbnail extractions on a different element.
@@ -230,6 +265,23 @@ async function grabFrameViaCanvas(
   options: Required<ExtractVideoFrameOptions>
 ): Promise<FrameData> {
   await seekVideoToTime(video, t);
+  // Did somebody else move the playhead while this was waiting?
+  //
+  // The read queue only serializes extractions against each other. The scrub
+  // queue writes `video.currentTime` directly and is not in it, so a drag during
+  // a read retargets the element — and this seek's `seeked` handler may well be
+  // woken by the drag's seek instead of its own. Drawing then yields the frame
+  // the drag landed on, filed under the timestamp that was asked for.
+  //
+  // `currentTime` answers with the requested position, which is exactly what is
+  // wanted here: if it no longer reads as `t`, the request was replaced. The
+  // tolerance covers the element snapping to the nearest decodable frame once the
+  // seek completes.
+  if (Math.abs(video.currentTime - t) > SUPERSEDED_SEEK_TOLERANCE_SEC) {
+    throw new Error(
+      `Seek to ${t}s was superseded by a seek to ${video.currentTime}s`,
+    );
+  }
   const canvas = drawFrameToCanvas(
     video,
     options.scale,


### PR DESCRIPTION
- **fix(annotate): never draw a frame a seek has not delivered yet**
- **fix(annotate): stop a failed frame read from taking the draft with it**
