### PR TITLE
Annotate workspace: id-based selection, validation that names screens, faster bootstrap, safer frame reads

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,10 @@ export default defineConfig([
     ".venv/**",
     "dist/**",
     "out/**",
+    // Gitignored agent scratch space: plans, and throwaway spikes that vendor
+    // third-party builds. CI never sees it, but linting it locally reports
+    // problems in code nobody here wrote or ships.
+    "plans/**",
     "src/app/(signed-in)/_trace/**",
   ]),
   ...compat.extends("next/core-web-vitals"),

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/components/filmstrip.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/redact-screen/components/filmstrip.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { CircleAlert } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FrameData, Redaction } from "../../types";
+import { countUnlabelledRedactions } from "../../../util";
 
 export function Filmstrip({
   screens,
@@ -25,6 +26,9 @@ export function Filmstrip({
           screen={screen}
           redactions={redactions[screen.id] ?? []}
           isSelected={focusViewIndex === index}
+          // Same predicate the step gate uses, so the screens ringed here are
+          // exactly the screens its error names.
+          hasError={countUnlabelledRedactions(redactions[screen.id]) > 0}
           onClick={() => setFocusViewIndex(index)}
         ></FilmstripItem>
       ))}

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/android/repair-screen-android.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/android/repair-screen-android.tsx
@@ -231,7 +231,6 @@ export function RepairScreenAndroid({
             gestures={currGestures}
             redactions={currRedactions}
             os={os}
-            handleSetTime={(_: number) => {}} // empty function
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/android/repair-screen-android.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/android/repair-screen-android.tsx
@@ -30,7 +30,7 @@ export function RepairScreenAndroid({
   draftFetchResult: DraftFetchResults;
 }) {
   const { setValue } = useFormContext<TraceFormData>();
-  const { focusViewIndex } = useNavigation();
+  const { focusedScreenId, focusedIndex } = useNavigation();
   const [watchScreens, watchVHs, watchGestures, watchRedactions] = useWatch({
     name: ["screens", "vhs", "gestures", "redactions"],
   });
@@ -40,6 +40,8 @@ export function RepairScreenAndroid({
   const originalGestures = useRef<{ [key: string]: ScreenGesture }>({});
   const originalRedactions = useRef<{ [key: string]: Redaction[] }>({});
   const currScreens = watchScreens as FrameData[];
+  const focusedAndroidScreen =
+    currScreens.find((screen) => screen.id === focusedScreenId) ?? null;
   const currVHs = watchVHs as { [key: string]: any };
   const currGestures = watchGestures as { [key: string]: ScreenGesture };
   const currRedactions = watchRedactions as { [key: string]: Redaction[] };
@@ -197,12 +199,12 @@ export function RepairScreenAndroid({
                   setShowBoxes={setShowBoxes}
                 />
               </div>
-              {focusViewIndex > -1 && focusViewIndex < currScreens.length ? (
+              {focusedAndroidScreen ? (
                 <FocusViewAndroid
-                  key={focusViewIndex}
-                  vh={currVHs[currScreens[focusViewIndex].id]}
-                  screen={currScreens[focusViewIndex]}
-                  isLastScreen={focusViewIndex === currScreens.length - 1}
+                  key={focusedAndroidScreen.id}
+                  vh={currVHs[focusedAndroidScreen.id]}
+                  screen={focusedAndroidScreen}
+                  isLastScreen={focusedIndex === currScreens.length - 1}
                   showBoxes={showBoxes}
                 />
               ) : (

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
@@ -141,7 +141,6 @@ function FilmstripItem({
   return (
     <motion.li
       className="cursor-pointer min-w-fit h-full max-w-full"
-      data-index={index}
       data-screen-id={screen.id}
       variants={card}
       initial="initial"

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
@@ -31,12 +31,12 @@ export function Filmstrip({
   os: Platform;
   handleSetTime: (t: number) => void;
 }) {
-  const { focusViewIndex, setFocusViewIndex, handleDeleteScreen } =
+  const { focusedScreenId, setFocusedScreenId, handleDeleteScreen } =
     useNavigation();
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (focusViewIndex < 0) {
+    if (focusedScreenId === null) {
       return;
     }
 
@@ -46,8 +46,10 @@ export function Filmstrip({
         return;
       }
 
+      // Queried by id, not position: an insert shifts every later index, so a
+      // positional selector can scroll to the wrong thumbnail.
       const selectedItem = container.querySelector<HTMLElement>(
-        `[data-index="${focusViewIndex}"]`,
+        `[data-screen-id="${focusedScreenId}"]`,
       );
       if (!selectedItem) {
         return;
@@ -71,7 +73,7 @@ export function Filmstrip({
     return () => {
       cancelAnimationFrame(frame);
     };
-  }, [focusViewIndex, screens.length]);
+  }, [focusedScreenId, screens.length]);
 
   return (
     <div ref={containerRef} className="h-full overflow-x-auto">
@@ -87,7 +89,7 @@ export function Filmstrip({
                 gesture={gestures[screen.id]}
                 redactions={redactions[screen.id] ?? []}
                 os={os}
-                isSelected={focusViewIndex === index}
+                isSelected={focusedScreenId === screen.id}
                 hasError={
                   isLast
                     ? false
@@ -95,7 +97,7 @@ export function Filmstrip({
                       gestures[screen.id].type === null ||
                       !validateGestureDescription(gestures[screen.id])
                 }
-                onClick={() => setFocusViewIndex(index)}
+                onClick={() => setFocusedScreenId(screen.id)}
                 handleSetTime={handleSetTime}
                 handleDeleteFrame={handleDeleteScreen}
               />
@@ -127,7 +129,7 @@ function FilmstripItem({
   isSelected?: boolean;
   hasError?: boolean;
   handleSetTime: (t: number) => void;
-  handleDeleteFrame: (index: number) => void;
+  handleDeleteFrame: (screenId: string) => void;
   onClick?: () => void;
 }) {
   const hasGestureCoordinates =
@@ -140,6 +142,7 @@ function FilmstripItem({
     <motion.li
       className="cursor-pointer min-w-fit h-full max-w-full"
       data-index={index}
+      data-screen-id={screen.id}
       variants={card}
       initial="initial"
       animate="animate"
@@ -166,7 +169,7 @@ function FilmstripItem({
           onClick={(e) => {
             // Prevent bubbling to parent click handlers that set focus/time
             e.stopPropagation();
-            handleDeleteFrame(index);
+            handleDeleteFrame(screen.id);
           }}
           className="inline-flex self-end items-center cursor-pointer"
           title="Delete snapshot"

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
@@ -23,16 +23,13 @@ export function Filmstrip({
   gestures,
   redactions,
   os,
-  handleSetTime,
 }: {
   screens: FrameData[];
   gestures: { [key: string]: ScreenGesture };
   redactions: { [screenId: string]: Redaction[] };
   os: Platform;
-  handleSetTime: (t: number) => void;
 }) {
-  const { focusedScreenId, setFocusedScreenId, handleDeleteScreen } =
-    useNavigation();
+  const { focusedScreenId, selectScreen, handleDeleteScreen } = useNavigation();
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -93,8 +90,7 @@ export function Filmstrip({
                 hasError={
                   isLast ? false : !isScreenAnnotationComplete(gestures[screen.id])
                 }
-                onClick={() => setFocusedScreenId(screen.id)}
-                handleSetTime={handleSetTime}
+                onClick={() => selectScreen(screen.id, "filmstrip")}
                 handleDeleteFrame={handleDeleteScreen}
               />
             );
@@ -113,7 +109,6 @@ function FilmstripItem({
   os,
   isSelected,
   hasError = false,
-  handleSetTime,
   handleDeleteFrame,
   onClick,
 }: {
@@ -124,7 +119,6 @@ function FilmstripItem({
   os: Platform;
   isSelected?: boolean;
   hasError?: boolean;
-  handleSetTime: (t: number) => void;
   handleDeleteFrame: (screenId: string) => void;
   onClick?: () => void;
 }) {
@@ -145,10 +139,7 @@ function FilmstripItem({
       layout="position"
       transition={spring()}
       key={`${screen.timestamp}-${screen.id}`}
-      onClick={() => {
-        onClick?.();
-        handleSetTime(screen.timestamp);
-      }}
+      onClick={onClick}
     >
       {/* Toolbar */}
       <div className="flex flex-row w-full items-center justify-between">

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/filmstrip.tsx
@@ -15,7 +15,7 @@ import Image from "next/image";
 import { card } from "../util";
 import { spring } from "@/lib/motion";
 import { findGestureOption } from "@/lib/utils/gesture-options";
-import { validateGestureDescription } from "../util";
+import { isScreenAnnotationComplete } from "../util";
 import { useEffect, useRef } from "react";
 
 export function Filmstrip({
@@ -91,11 +91,7 @@ export function Filmstrip({
                 os={os}
                 isSelected={focusedScreenId === screen.id}
                 hasError={
-                  isLast
-                    ? false
-                    : !gestures[screen.id] ||
-                      gestures[screen.id].type === null ||
-                      !validateGestureDescription(gestures[screen.id])
+                  isLast ? false : !isScreenAnnotationComplete(gestures[screen.id])
                 }
                 onClick={() => setFocusedScreenId(screen.id)}
                 handleSetTime={handleSetTime}

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/extract-frames-timeline.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/extract-frames-timeline.tsx
@@ -34,7 +34,7 @@ export type FrameTimelineProps = {
   currentTime: number;
   videoDuration: number;
   isPlaying: boolean;
-  handleSetTime: (t: number) => void;
+  handleSetTime: (t: number, options?: { syncFocus?: boolean }) => void;
   handlePlayPause: () => void;
   handleCapture: () => void;
   onScrubPreviewTimeChange?: (t: number | null) => void;
@@ -164,14 +164,16 @@ export default function FrameTimeline({
     ? { type: "tween" as const, ease: "linear" as const, duration: 0.04 }
     : spring({ duration: 0.12 });
 
+  // Mouse equivalents of the j/l keys, so they drag the focused screen along
+  // the same way an explicit seek does.
   const handleSkipForward = () => {
     const newTime = Math.min(currentTime + 5, videoDuration);
-    handleSetTime(newTime);
+    handleSetTime(newTime, { syncFocus: true });
   };
 
   const handleSkipBackward = () => {
     const newTime = Math.max(currentTime - 5, 0);
-    handleSetTime(newTime);
+    handleSetTime(newTime, { syncFocus: true });
   };
 
   const displayedThumbnails = useMemo(() => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
@@ -5,7 +5,19 @@ export const TIMELINE_THUMB_HEIGHT = 128;
 export const PREVIEW_THUMB_HEIGHT = 1440;
 export const TIMELINE_THUMB_JPEG_QUALITY = 0.84;
 export const PREVIEW_THUMB_JPEG_QUALITY = 0.9;
-export const SCRUB_SEEK_INTERVAL_MS = 125;
+/**
+ * Minimum gap between seeks while scrubbing.
+ *
+ * Exists because assigning `currentTime` while a seek is in flight aborts it and
+ * starts over, so an unthrottled drag could thrash the decoder badly enough that
+ * no seek ever completed — the original reason scrubbing appeared to break.
+ *
+ * Measured seek-to-frame-presented latency is 14-38ms median and 30-93ms at p95
+ * across Chrome and Safari, so the old 125ms was throttling several times slower
+ * than the hardware and holding back both the frame rate during a drag and how
+ * quickly the real frame appears once the pointer stops.
+ */
+export const SCRUB_SEEK_INTERVAL_MS = 70;
 export const FRAME_STEP_SECONDS = 1 / 30;
 export const STEP_COMMIT_DELAY_MS = 120;
 export const PREVIEW_SWAP_DELAY_MS = 70;

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
@@ -16,6 +16,12 @@ export const PREVIEW_SWAP_DELAY_MS = 70;
  * element is showing what was asked for.
  */
 export const PREVIEW_MATCH_TOLERANCE = 2 / 30;
+/**
+ * Backstop for uncovering the video when `requestVideoFrameCallback` is missing
+ * or never fires. Long enough that a normal presentation wins the race, short
+ * enough that a worker does not sit looking at a thumbnail.
+ */
+export const PREVIEW_REVEAL_TIMEOUT_MS = 250;
 export const VIDEO_LOAD_TIMEOUT_MS = 30000;
 
 export type PreviewThumbnail = {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/ios-helpers.ts
@@ -9,6 +9,13 @@ export const SCRUB_SEEK_INTERVAL_MS = 125;
 export const FRAME_STEP_SECONDS = 1 / 30;
 export const STEP_COMMIT_DELAY_MS = 120;
 export const PREVIEW_SWAP_DELAY_MS = 70;
+/**
+ * How close the landed frame has to be to the requested moment before the real
+ * video can replace the thumbnail. Browsers snap to the nearest decodable frame,
+ * so an exact match never holds; two frames at 30fps is close enough that the
+ * element is showing what was asked for.
+ */
+export const PREVIEW_MATCH_TOLERANCE = 2 / 30;
 export const VIDEO_LOAD_TIMEOUT_MS = 30000;
 
 export type PreviewThumbnail = {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -35,8 +35,12 @@ export function RepairScreenIOS({
   os: Platform;
   draftFetchResult: DraftFetchResults;
 }) {
-  const { focusViewIndex, setFocusViewIndex, registerSeekToTime } =
-    useNavigation();
+  const {
+    focusedScreenId,
+    setFocusedScreenId,
+    focusedIndex,
+    registerSeekToTime,
+  } = useNavigation();
   const { setValue } = useFormContext<TraceFormData>();
   const { register: registerScreenUrl } = useScreenBlobRegistry();
   const [watchScreens, watchGestures, watchRedactions] = useWatch({
@@ -47,17 +51,15 @@ export function RepairScreenIOS({
   const gestures = watchGestures as { [key: string]: ScreenGesture };
   const redactions = watchRedactions as { [key: string]: Redaction[] };
   const focusedScreen =
-    focusViewIndex > -1 && focusViewIndex < screens.length
-      ? screens[focusViewIndex]
-      : null;
+    screens.find((screen) => screen.id === focusedScreenId) ?? null;
   const captureMarkers = useMemo(
     () =>
-      screens.map((screen, index) => ({
+      screens.map((screen) => ({
         id: screen.id,
         timestamp: screen.timestamp,
-        isFocused: focusViewIndex === index,
+        isFocused: screen.id === focusedScreenId,
       })),
-    [focusViewIndex, screens],
+    [focusedScreenId, screens],
   );
 
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -86,8 +88,8 @@ export function RepairScreenIOS({
 
   const { syncFocusToTimestamp } = useIosScreenFocusSync({
     screens,
-    focusViewIndex,
-    setFocusViewIndex,
+    focusedScreenId,
+    setFocusedScreenId,
   });
 
   // Bootstrap: load video, populate screens, expose duration + thumbnails.
@@ -117,7 +119,7 @@ export function RepairScreenIOS({
   } = useIosVideoPlayback({
     videoRef,
     videoDuration,
-    focusViewIndex,
+    focusedScreenId,
     onLivePhotoStart,
   });
 
@@ -232,10 +234,10 @@ export function RepairScreenIOS({
     "r",
     (e) => {
       e.preventDefault();
-      if (focusViewIndex < 0 || focusViewIndex >= screens.length) return;
-      handleLivePhoto(screens[focusViewIndex].timestamp);
+      if (!focusedScreen) return;
+      handleLivePhoto(focusedScreen.timestamp);
     },
-    [focusViewIndex, screens, handleLivePhoto],
+    [focusedScreen, handleLivePhoto],
   );
 
   useHotkeys(
@@ -310,7 +312,7 @@ export function RepairScreenIOS({
               <RepairFocusPanelIOS
                 taskDescription={taskDescription}
                 focusedScreen={focusedScreen}
-                isLastScreen={focusViewIndex === screens.length - 1}
+                isLastScreen={focusedIndex === screens.length - 1}
                 isLivePhotoActive={isLivePhotoActive}
                 onLivePhoto={handleLivePhoto}
               />

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -6,6 +6,7 @@ import {
 import { Filmstrip } from "../filmstrip";
 import FrameTimeline from "./extract-frames-timeline";
 import { useHotkeys } from "react-hotkeys-hook";
+import { toast } from "sonner";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { extractVideoFrame, useFormFieldKeyPressGuard } from "../../util";
 import { FrameData, Redaction, TraceFormData } from "../../../types";
@@ -192,11 +193,22 @@ export function RepairScreenIOS({
 
   const handleCaptureFrame = useCallback(async () => {
     if (!videoRef.current) return;
-    const f = await extractVideoFrame(videoRef.current, currentTime, {
-      mimeType: "image/png",
-      output: "object-url",
-      preferOffscreenCanvas: true,
-    });
+    let f: FrameData;
+    try {
+      f = await extractVideoFrame(videoRef.current, currentTime, {
+        mimeType: "image/png",
+        output: "object-url",
+        preferOffscreenCanvas: true,
+      });
+    } catch (error) {
+      // A read can now fail rather than guess: a seek that never completes
+      // rejects instead of drawing whatever frame the element still holds.
+      // Without this the rejection was unhandled and `c` simply did nothing,
+      // which is indistinguishable from a missed keypress.
+      console.error(`Could not capture the current frame: ${error}`);
+      toast.error("Could not capture this frame. Try again.");
+      return;
+    }
     registerScreenUrl(f.src);
     setValue(
       "screens",

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -217,7 +217,12 @@ export function RepairScreenIOS({
       "screens",
       [...screens, f].sort((a, b) => a.timestamp - b.timestamp),
     );
-  }, [currentTime, registerScreenUrl, screens, setValue]);
+    // Focus what was just captured. Every screen but the last needs a gesture,
+    // so capturing is always followed by annotating it — and leaving focus
+    // behind meant hunting for the new frame in the filmstrip first. No seek is
+    // needed: the playhead is already at this screen's timestamp.
+    setFocusedScreenId(f.id);
+  }, [currentTime, registerScreenUrl, screens, setFocusedScreenId, setValue]);
 
   // Workspace keybinds
   useHotkeys("space", async (e) => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -35,12 +35,8 @@ export function RepairScreenIOS({
   os: Platform;
   draftFetchResult: DraftFetchResults;
 }) {
-  const {
-    focusedScreenId,
-    setFocusedScreenId,
-    focusedIndex,
-    registerSeekToTime,
-  } = useNavigation();
+  const { focusedScreenId, selectScreen, focusedIndex, playheadRequest } =
+    useNavigation();
   const { setValue } = useFormContext<TraceFormData>();
   const { register: registerScreenUrl } = useScreenBlobRegistry();
   const [watchScreens, watchGestures, watchRedactions] = useWatch({
@@ -64,8 +60,8 @@ export function RepairScreenIOS({
 
   const videoRef = useRef<HTMLVideoElement>(null);
   const didKeyPressStartInFormField = useFormFieldKeyPressGuard();
-  // Holds a jump's seek target while the recording is still loading.
-  const pendingJumpSeekRef = useRef<number | null>(null);
+  // Highest playhead request already applied, so each is placed once.
+  const appliedPlayheadNonceRef = useRef<number | null>(null);
 
   const videoFiles = useMemo(() => {
     const regexRule = /\.(mp4|mov)$/;
@@ -89,7 +85,7 @@ export function RepairScreenIOS({
   const { syncFocusToTimestamp } = useIosScreenFocusSync({
     screens,
     focusedScreenId,
-    setFocusedScreenId,
+    selectScreen,
   });
 
   // Bootstrap: load video, populate screens, expose duration + thumbnails.
@@ -152,39 +148,27 @@ export function RepairScreenIOS({
     syncFocusToTimestamp,
   });
 
-  // Let a jump to a screen (feedback checklist chip) carry the playhead with it.
-  // `syncFocus: false` matters: handleSetTime otherwise re-derives focus from the
-  // nearest screen timestamp, which lands on a neighbour when two screens sit
-  // close together and would override the jump that asked for this seek.
+  // Reconcile the recording towards where it has been asked to sit.
+  //
+  // Declarative on purpose. Bootstrap seeks the live element while extracting
+  // frames — the warmup grab alone drags it to 0.1s — so a seek issued during
+  // loading gets undone. Expressing the target as state means this effect simply
+  // runs again once `isVideoReady` flips, instead of a queue trying to guess the
+  // right moment to fire.
+  //
+  // No focus sync: the request came *from* a selection, and re-deriving focus
+  // from the landed timestamp is what let a click settle on a neighbouring
+  // screen when two sit close together.
   useEffect(() => {
-    registerSeekToTime((timestamp) => {
-      // Bootstrap seeks the live video element while extracting frames — the
-      // warmup grab alone drags it to 0.1s — and the `seeked` listener writes
-      // that back over currentTime. Seeking before it finishes gets undone, and
-      // a jump applies only once, so it never self-corrects. Hold it instead.
-      if (!isVideoReady) {
-        pendingJumpSeekRef.current = timestamp;
-        return;
-      }
-      handleSetTime(timestamp, { syncFocus: false });
-    });
-    return () => registerSeekToTime(null);
-  }, [handleSetTime, isVideoReady, registerSeekToTime]);
-
-  // Place a jump seek that arrived while the recording was still loading.
-  // Reachable whenever the step is re-entered with a jump still armed: this
-  // component and the video both remount, so the jump lands mid-bootstrap.
-  useEffect(() => {
-    if (!isVideoReady) {
+    if (!playheadRequest || !isVideoReady) {
       return;
     }
-    const pendingSeek = pendingJumpSeekRef.current;
-    if (pendingSeek === null) {
+    if (appliedPlayheadNonceRef.current === playheadRequest.nonce) {
       return;
     }
-    pendingJumpSeekRef.current = null;
-    handleSetTime(pendingSeek, { syncFocus: false });
-  }, [handleSetTime, isVideoReady]);
+    appliedPlayheadNonceRef.current = playheadRequest.nonce;
+    handleSetTime(playheadRequest.time);
+  }, [handleSetTime, isVideoReady, playheadRequest]);
 
   // Now that scrub-preview exists, point the lazy refs at the real callbacks.
   useEffect(() => {
@@ -221,8 +205,8 @@ export function RepairScreenIOS({
     // so capturing is always followed by annotating it — and leaving focus
     // behind meant hunting for the new frame in the filmstrip first. No seek is
     // needed: the playhead is already at this screen's timestamp.
-    setFocusedScreenId(f.id);
-  }, [currentTime, registerScreenUrl, screens, setFocusedScreenId, setValue]);
+    selectScreen(f.id, "capture");
+  }, [currentTime, registerScreenUrl, screens, selectScreen, setValue]);
 
   // Workspace keybinds
   useHotkeys("space", async (e) => {
@@ -249,7 +233,7 @@ export function RepairScreenIOS({
     "j",
     (e) => {
       e.preventDefault();
-      handleSetTime(currentTime - 5);
+      handleSetTime(currentTime - 5, { syncFocus: true });
     },
     [currentTime, handleSetTime],
   );
@@ -258,7 +242,7 @@ export function RepairScreenIOS({
     "l",
     (e) => {
       e.preventDefault();
-      handleSetTime(currentTime + 5);
+      handleSetTime(currentTime + 5, { syncFocus: true });
     },
     [currentTime, handleSetTime],
   );
@@ -338,7 +322,6 @@ export function RepairScreenIOS({
               gestures={gestures}
               redactions={redactions}
               os={os}
-              handleSetTime={handleSetTime}
             />
             <FrameTimeline
               thumbnails={thumbnails}

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/repair-screen-ios.tsx
@@ -187,6 +187,7 @@ export function RepairScreenIOS({
     scheduleScrubSeek,
     handleScrubCommit,
     setPausedPreviewTime,
+    onScrubActiveChange: handleScrubActiveChange,
   });
 
   const handleCaptureFrame = useCallback(async () => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
@@ -1,13 +1,23 @@
 /**
- * Temporary instrumentation for deciding whether the thumbnail preview pipeline
- * can be replaced by native video seeking.
+ * Instrumentation for the scrub pipeline.
  *
- * Measures the two numbers that decide it:
+ * Written to answer whether the thumbnail preview could be replaced by native
+ * video seeking. It could not, and the numbers that settled it are worth keeping
+ * around:
  *
  *  - how long a seek takes to actually put a frame on screen, and how often that
- *    never happens (the reason native scrubbing felt broken before), and
- *  - how much of bootstrap is spent extracting preview thumbnails, which is what
- *    going native would buy back.
+ *    never happens, and
+ *  - how much of bootstrap is spent extracting preview thumbnails.
+ *
+ * It has since earned a second job. `stalls` distinguishes the two browsers in a
+ * way nothing else here does: `requestVideoFrameCallback` fires for a paused seek
+ * in Chrome and never fires in Safari, so a Safari session reports every seek as
+ * a stall while Chrome reports none. That is the same underlying fault as
+ * <https://bugs.webkit.org/show_bug.cgi?id=153588>, which is why the settled
+ * frame can be wrong on Safari and is not wrong on Chrome.
+ *
+ * So this is not dead code awaiting deletion — it is how that bug gets measured
+ * next time, and how any audit of already-captured screens would be checked.
  *
  * Off unless switched on, so it costs a boolean check per seek otherwise. Enable
  * with `?scrubProfiling=1` on the URL, or persistently:
@@ -15,8 +25,6 @@
  *     localStorage.setItem("odim:scrub-profiling", "1")
  *
  * Then scrub around and call `__odimScrubProfile.summary()` in the console.
- *
- * Delete this file once the question is settled.
  */
 
 type VideoWithFrameCallback = HTMLVideoElement & {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
@@ -1,0 +1,240 @@
+/**
+ * Temporary instrumentation for deciding whether the thumbnail preview pipeline
+ * can be replaced by native video seeking.
+ *
+ * Measures the two numbers that decide it:
+ *
+ *  - how long a seek takes to actually put a frame on screen, and how often that
+ *    never happens (the reason native scrubbing felt broken before), and
+ *  - how much of bootstrap is spent extracting preview thumbnails, which is what
+ *    going native would buy back.
+ *
+ * Off unless switched on, so it costs a boolean check per seek otherwise. Enable
+ * with `?scrubProfiling=1` on the URL, or persistently:
+ *
+ *     localStorage.setItem("odim:scrub-profiling", "1")
+ *
+ * Then scrub around and call `__odimScrubProfile.summary()` in the console.
+ *
+ * Delete this file once the question is settled.
+ */
+
+type VideoWithFrameCallback = HTMLVideoElement & {
+  requestVideoFrameCallback?: (
+    callback: (now: number, metadata: { mediaTime: number }) => void,
+  ) => number;
+  cancelVideoFrameCallback?: (handle: number) => void;
+};
+
+interface SeekSample {
+  /** Where the seek asked to land. */
+  requestedTime: number;
+  /** Where the presented frame actually was, when the browser reports it. */
+  presentedTime: number | null;
+  /** Issue to presentation, in milliseconds. */
+  latencyMs: number;
+  /** Never presented within the stall threshold. */
+  stalled: boolean;
+}
+
+/** A seek not presented within this long counts as a stall, not slow. */
+const STALL_THRESHOLD_MS = 1000;
+
+const samples: SeekSample[] = [];
+const phaseTimings: Record<string, number[]> = {};
+let supersededCount = 0;
+let isEnabledCache: boolean | null = null;
+let isInstalled = false;
+
+let inFlight: {
+  requestedTime: number;
+  startedAt: number;
+  frameHandle: number | null;
+  stallTimeout: number | null;
+} | null = null;
+
+export function isScrubProfilingEnabled(): boolean {
+  if (isEnabledCache !== null) {
+    return isEnabledCache;
+  }
+  if (typeof window === "undefined") {
+    return false;
+  }
+  let enabled = false;
+  try {
+    enabled = window.localStorage.getItem("odim:scrub-profiling") === "1";
+  } catch {
+    // Storage can be unavailable; the query parameter still works.
+  }
+  if (!enabled) {
+    enabled = new URLSearchParams(window.location.search).has("scrubProfiling");
+  }
+  isEnabledCache = enabled;
+  return enabled;
+}
+
+function percentile(sorted: number[], fraction: number): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(sorted.length * fraction) - 1),
+  );
+  return sorted[index];
+}
+
+function round(value: number, places = 1): number {
+  const factor = 10 ** places;
+  return Math.round(value * factor) / factor;
+}
+
+function summary() {
+  const presented = samples.filter((sample) => !sample.stalled);
+  const latencies = presented
+    .map((sample) => sample.latencyMs)
+    .sort((a, b) => a - b);
+  const errors = presented
+    .filter((sample) => sample.presentedTime !== null)
+    .map((sample) =>
+      Math.abs((sample.presentedTime as number) - sample.requestedTime),
+    )
+    .sort((a, b) => a - b);
+
+  const result = {
+    seeks: samples.length,
+    presented: presented.length,
+    stalls: samples.filter((sample) => sample.stalled).length,
+    /** Seeks abandoned because the pointer moved on before they landed. */
+    superseded: supersededCount,
+    latencyMsP50: round(percentile(latencies, 0.5)),
+    latencyMsP95: round(percentile(latencies, 0.95)),
+    latencyMsMax: round(latencies[latencies.length - 1] ?? 0),
+    /** How far the presented frame sat from the requested moment, in seconds. */
+    frameErrorSecP50: round(percentile(errors, 0.5), 3),
+    frameErrorSecMax: round(errors[errors.length - 1] ?? 0, 3),
+  };
+
+  const phases = Object.fromEntries(
+    Object.entries(phaseTimings).map(([name, values]) => [
+      name,
+      {
+        runs: values.length,
+        totalMs: round(values.reduce((sum, value) => sum + value, 0)),
+        lastMs: round(values[values.length - 1] ?? 0),
+      },
+    ]),
+  );
+
+  console.table(result);
+  console.table(phases);
+  return { ...result, phases };
+}
+
+function reset() {
+  samples.length = 0;
+  supersededCount = 0;
+  Object.keys(phaseTimings).forEach((key) => delete phaseTimings[key]);
+}
+
+function install() {
+  if (isInstalled || typeof window === "undefined") {
+    return;
+  }
+  isInstalled = true;
+  (
+    window as unknown as { __odimScrubProfile: unknown }
+  ).__odimScrubProfile = { summary, reset, samples, phaseTimings };
+  console.info(
+    "[scrub-profiler] recording. Call __odimScrubProfile.summary() when done.",
+  );
+}
+
+function settleInFlight(presentedTime: number | null, stalled: boolean) {
+  if (!inFlight) {
+    return;
+  }
+  if (inFlight.stallTimeout !== null) {
+    window.clearTimeout(inFlight.stallTimeout);
+  }
+  samples.push({
+    requestedTime: inFlight.requestedTime,
+    presentedTime,
+    latencyMs: performance.now() - inFlight.startedAt,
+    stalled,
+  });
+  inFlight = null;
+}
+
+/**
+ * Call immediately after assigning `video.currentTime`.
+ *
+ * Timing ends when the browser reports a frame presented, which is the moment
+ * the worker can actually see it — `seeked` fires earlier and would flatter the
+ * numbers.
+ */
+export function recordSeekIssued(
+  video: HTMLVideoElement,
+  requestedTime: number,
+): void {
+  if (!isScrubProfilingEnabled()) {
+    return;
+  }
+  install();
+
+  const videoWithCallback = video as VideoWithFrameCallback;
+
+  if (inFlight) {
+    // The pointer moved on before this one landed. Not a stall — the opposite,
+    // it says the decoder is behind the input.
+    if (inFlight.frameHandle !== null) {
+      videoWithCallback.cancelVideoFrameCallback?.(inFlight.frameHandle);
+    }
+    if (inFlight.stallTimeout !== null) {
+      window.clearTimeout(inFlight.stallTimeout);
+    }
+    inFlight = null;
+    supersededCount += 1;
+  }
+
+  const started = performance.now();
+  inFlight = {
+    requestedTime,
+    startedAt: started,
+    frameHandle: null,
+    stallTimeout: window.setTimeout(
+      () => settleInFlight(null, true),
+      STALL_THRESHOLD_MS,
+    ),
+  };
+
+  if (typeof videoWithCallback.requestVideoFrameCallback === "function") {
+    inFlight.frameHandle = videoWithCallback.requestVideoFrameCallback(
+      (_now, metadata) => settleInFlight(metadata.mediaTime, false),
+    );
+    return;
+  }
+
+  // No frame-presentation support: fall back to `seeked`, and note that these
+  // latencies are optimistic by however long painting takes.
+  const onSeeked = () => {
+    video.removeEventListener("seeked", onSeeked);
+    settleInFlight(video.currentTime, false);
+  };
+  video.addEventListener("seeked", onSeeked, { once: true });
+}
+
+/**
+ * Record how long a named bootstrap phase took.
+ *
+ * `previewThumbnails` is the one that matters — it is the work that disappears
+ * if the preview pipeline is removed.
+ */
+export function recordPhase(name: string, durationMs: number): void {
+  if (!isScrubProfilingEnabled()) {
+    return;
+  }
+  install();
+  phaseTimings[name] = phaseTimings[name] ?? [];
+  phaseTimings[name].push(durationMs);
+}

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/scrub-profiler.ts
@@ -35,6 +35,20 @@ interface SeekSample {
   latencyMs: number;
   /** Never presented within the stall threshold. */
   stalled: boolean;
+  /**
+   * Element state captured at stall time, to tell two very different things
+   * apart: an element genuinely stuck mid-seek, which is the failure that makes
+   * native scrubbing unusable, versus a seek that completed while
+   * `requestVideoFrameCallback` simply never fired — a reporting gap with no
+   * effect on what the worker sees.
+   */
+  stallState?: {
+    currentTime: number;
+    seeking: boolean;
+    readyState: number;
+    /** The element sits at the requested moment despite no frame callback. */
+    reachedTarget: boolean;
+  };
 }
 
 /** A seek not presented within this long counts as a stall, not slow. */
@@ -47,6 +61,7 @@ let isEnabledCache: boolean | null = null;
 let isInstalled = false;
 
 let inFlight: {
+  video: HTMLVideoElement;
   requestedTime: number;
   startedAt: number;
   frameHandle: number | null;
@@ -101,10 +116,21 @@ function summary() {
     )
     .sort((a, b) => a - b);
 
+  const stalls = samples.filter((sample) => sample.stalled);
+  // A stall where the element reached the target and is no longer seeking means
+  // the frame was there and only the callback went missing.
+  const unreportedFrames = stalls.filter(
+    (sample) => sample.stallState?.reachedTarget && !sample.stallState.seeking,
+  ).length;
+
   const result = {
     seeks: samples.length,
     presented: presented.length,
-    stalls: samples.filter((sample) => sample.stalled).length,
+    stalls: stalls.length,
+    /** Stalls that were really the element stuck mid-seek. */
+    stalledStuck: stalls.length - unreportedFrames,
+    /** Stalls that were only a missing frame callback. */
+    stalledButFramePresent: unreportedFrames,
     /** Seeks abandoned because the pointer moved on before they landed. */
     superseded: supersededCount,
     latencyMsP50: round(percentile(latencies, 0.5)),
@@ -157,11 +183,21 @@ function settleInFlight(presentedTime: number | null, stalled: boolean) {
   if (inFlight.stallTimeout !== null) {
     window.clearTimeout(inFlight.stallTimeout);
   }
+
+  const { video, requestedTime } = inFlight;
   samples.push({
-    requestedTime: inFlight.requestedTime,
+    requestedTime,
     presentedTime,
     latencyMs: performance.now() - inFlight.startedAt,
     stalled,
+    stallState: stalled
+      ? {
+          currentTime: video.currentTime,
+          seeking: video.seeking,
+          readyState: video.readyState,
+          reachedTarget: Math.abs(video.currentTime - requestedTime) <= 0.05,
+        }
+      : undefined,
   });
   inFlight = null;
 }
@@ -199,6 +235,7 @@ export function recordSeekIssued(
 
   const started = performance.now();
   inFlight = {
+    video,
     requestedTime,
     startedAt: started,
     frameHandle: null,

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-screen-focus-sync.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-screen-focus-sync.ts
@@ -1,17 +1,24 @@
 import { useCallback } from "react";
 import { FrameData } from "../../../types";
+import { SelectScreenSource } from "../../repair-screen";
 import { findNearestScreenIndex } from "./ios-helpers";
 
 interface UseIosScreenFocusSyncArgs {
   screens: FrameData[];
   focusedScreenId: string | null;
-  setFocusedScreenId: (screenId: string | null) => void;
+  selectScreen: (screenId: string | null, source: SelectScreenSource) => void;
 }
 
+/**
+ * Derives the focused screen from a playhead position — the one-way half of the
+ * relationship. Selections made this way are tagged `"playhead"`, which is
+ * excluded from moving the recording, so the derivation cannot feed back into
+ * the position it came from.
+ */
 export function useIosScreenFocusSync({
   screens,
   focusedScreenId,
-  setFocusedScreenId,
+  selectScreen,
 }: UseIosScreenFocusSyncArgs) {
   const getNearestScreenIndex = useCallback(
     (time: number) => findNearestScreenIndex(screens, time),
@@ -26,10 +33,10 @@ export function useIosScreenFocusSync({
       }
       const nextScreenId = screens[nextIndex].id;
       if (nextScreenId !== focusedScreenId) {
-        setFocusedScreenId(nextScreenId);
+        selectScreen(nextScreenId, "playhead");
       }
     },
-    [focusedScreenId, getNearestScreenIndex, screens, setFocusedScreenId],
+    [focusedScreenId, getNearestScreenIndex, screens, selectScreen],
   );
 
   return { getNearestScreenIndex, syncFocusToTimestamp };

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-screen-focus-sync.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-screen-focus-sync.ts
@@ -4,14 +4,14 @@ import { findNearestScreenIndex } from "./ios-helpers";
 
 interface UseIosScreenFocusSyncArgs {
   screens: FrameData[];
-  focusViewIndex: number;
-  setFocusViewIndex: (index: number) => void;
+  focusedScreenId: string | null;
+  setFocusedScreenId: (screenId: string | null) => void;
 }
 
 export function useIosScreenFocusSync({
   screens,
-  focusViewIndex,
-  setFocusViewIndex,
+  focusedScreenId,
+  setFocusedScreenId,
 }: UseIosScreenFocusSyncArgs) {
   const getNearestScreenIndex = useCallback(
     (time: number) => findNearestScreenIndex(screens, time),
@@ -21,11 +21,15 @@ export function useIosScreenFocusSync({
   const syncFocusToTimestamp = useCallback(
     (time: number) => {
       const nextIndex = getNearestScreenIndex(time);
-      if (nextIndex >= 0 && nextIndex !== focusViewIndex) {
-        setFocusViewIndex(nextIndex);
+      if (nextIndex < 0) {
+        return;
+      }
+      const nextScreenId = screens[nextIndex].id;
+      if (nextScreenId !== focusedScreenId) {
+        setFocusedScreenId(nextScreenId);
       }
     },
-    [focusViewIndex, getNearestScreenIndex, setFocusViewIndex],
+    [focusedScreenId, getNearestScreenIndex, screens, setFocusedScreenId],
   );
 
   return { getNearestScreenIndex, syncFocusToTimestamp };

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -9,6 +9,7 @@ import {
 } from "react";
 
 
+import { recordSeekIssued } from "./scrub-profiler";
 import {
   PREVIEW_MATCH_TOLERANCE,
   PREVIEW_REVEAL_TIMEOUT_MS,
@@ -243,6 +244,7 @@ export function useIosScrubPreview({
       isSeekInFlightRef.current = true;
       pendingSeekTimeRef.current = nextTime;
       video.currentTime = nextTime;
+      recordSeekIssued(video, nextTime);
       if (scrubPreviewTimeRef.current === null) {
         lastCommittedVideoTimeRef.current = nextTime;
         updateCurrentTime(nextTime);
@@ -463,6 +465,7 @@ export function useIosScrubPreview({
       isSeekInFlightRef.current = true;
       pendingSeekTimeRef.current = t;
       video.currentTime = t;
+      recordSeekIssued(video, t);
       updateCurrentTime(t);
     },
     [

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -178,12 +178,21 @@ export function useIosScrubPreview({
       requestAnimationFrame(() => {
         isSeekInFlightRef.current = false;
         pendingSeekTimeRef.current = null;
-        const scrubTargetTime = scrubPreviewTimeRef.current;
-        if (
+
+        // Has the playhead come to rest? The drag is over and nothing newer is
+        // queued, so wherever the element landed is the final position.
+        //
+        // Deliberately not an exact comparison against the requested time.
+        // Browsers snap `currentTime` to the nearest decodable frame, so the
+        // landed value usually differs by more than a millisecond — gating on an
+        // exact match left the coarse thumbnail up at random, which is why the
+        // preview and the real frame sometimes still disagreed after mouseup.
+        const hasPlayheadSettled =
           !isScrubPreviewActiveRef.current &&
-          scrubTargetTime !== null &&
-          Math.abs(video.currentTime - scrubTargetTime) <= 0.001
-        ) {
+          scrubQueuedSeekTimeRef.current === null &&
+          scrubSeekTimeoutRef.current === null;
+
+        if (hasPlayheadSettled && scrubPreviewTimeRef.current !== null) {
           scrubPreviewTimeRef.current = null;
           setScrubPreviewTime(null);
         }
@@ -197,16 +206,13 @@ export function useIosScrubPreview({
           updateCurrentTime(video.currentTime);
         }
 
-        // Reveal the real frame now that the seek has landed. The overlay is
-        // only meant to cover seek latency, but a preview thumbnail is a
-        // nearest-neighbour pick off a coarse grid — roughly 1.2s apart on a
-        // long recording, so up to ~0.6s from the playhead. Leaving it up means
-        // the worker aims with an image that can be half a second stale while
-        // `c` captures the accurate frame underneath it.
-        if (
-          !isScrubPreviewActiveRef.current &&
-          scrubPreviewTimeRef.current === null
-        ) {
+        // Reveal the real frame. The overlay is only meant to cover seek
+        // latency, but a preview thumbnail is a nearest-neighbour pick off a
+        // coarse grid — roughly 1.2s apart on a long recording, so up to ~0.6s
+        // from the playhead. Leaving it up means the worker aims with an image
+        // that can be half a second stale while `c` captures the accurate frame
+        // underneath it.
+        if (hasPlayheadSettled) {
           setPausedPreviewTime(null);
         }
       });

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -311,7 +311,10 @@ export function useIosScrubPreview({
 
       t = Math.max(0, Math.min(t, videoDuration));
 
-      if (options?.syncFocus ?? true) {
+      // Opt-in. A seek only drags the focused screen along when the seek itself
+      // was the worker's intent — scrubbing, frame stepping, the ±5s keys. A seek
+      // that exists because a screen was selected must not reassign selection.
+      if (options?.syncFocus) {
         syncFocusToTimestamp(t);
       }
 

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -11,11 +11,22 @@ import {
 
 import {
   PREVIEW_MATCH_TOLERANCE,
+  PREVIEW_REVEAL_TIMEOUT_MS,
   PREVIEW_SWAP_DELAY_MS,
   PreviewThumbnail,
   SCRUB_SEEK_INTERVAL_MS,
   findNearestPreviewThumbnail,
 } from "./ios-helpers";
+
+/**
+ * `requestVideoFrameCallback` is not in every TypeScript DOM lib, and is absent
+ * on older browsers, so it is described here and feature-detected at the call
+ * site rather than assumed.
+ */
+type VideoWithFrameCallback = HTMLVideoElement & {
+  requestVideoFrameCallback?: (callback: () => void) => number;
+  cancelVideoFrameCallback?: (handle: number) => void;
+};
 
 interface UseIosScrubPreviewArgs {
   videoRef: RefObject<HTMLVideoElement | null>;
@@ -54,6 +65,8 @@ export function useIosScrubPreview({
   const activePreviewFrameSrcRef = useRef<string | null>(null);
   /** The moment the display is trying to represent, wherever the request came from. */
   const previewTargetTimeRef = useRef<number | null>(null);
+  const frameCallbackHandleRef = useRef<number | null>(null);
+  const revealFallbackTimeoutRef = useRef<number | null>(null);
 
   const [scrubPreviewTime, setScrubPreviewTime] = useState<number | null>(null);
   const [pausedPreviewTime, setPausedPreviewTime] = useState<number | null>(
@@ -82,6 +95,47 @@ export function useIosScrubPreview({
     [previewThumbnails],
   );
 
+  const cancelPendingReveal = useCallback(() => {
+    const video = videoRef.current as VideoWithFrameCallback | null;
+    if (frameCallbackHandleRef.current !== null) {
+      video?.cancelVideoFrameCallback?.(frameCallbackHandleRef.current);
+      frameCallbackHandleRef.current = null;
+    }
+    if (revealFallbackTimeoutRef.current !== null) {
+      window.clearTimeout(revealFallbackTimeoutRef.current);
+      revealFallbackTimeoutRef.current = null;
+    }
+  }, [videoRef]);
+
+  /**
+   * Uncover the element once it has actually presented a frame.
+   *
+   * `seeked` only says the seek finished, not that anything has been painted,
+   * and uncovering in that gap is what showed a blank flash before the frame
+   * appeared. `requestVideoFrameCallback` fires on presentation, which is the
+   * event we actually want. A timeout backs it up: on a browser that does not
+   * implement it, or does not fire it for a paused element, the reveal still
+   * happens rather than leaving the thumbnail up for good.
+   */
+  const revealWhenFramePresented = useCallback(() => {
+    cancelPendingReveal();
+
+    const reveal = () => {
+      cancelPendingReveal();
+      setIsPreviewNeeded(false);
+    };
+
+    const video = videoRef.current as VideoWithFrameCallback | null;
+    revealFallbackTimeoutRef.current = window.setTimeout(
+      reveal,
+      PREVIEW_REVEAL_TIMEOUT_MS,
+    );
+
+    if (video && typeof video.requestVideoFrameCallback === "function") {
+      frameCallbackHandleRef.current = video.requestVideoFrameCallback(reveal);
+    }
+  }, [cancelPendingReveal, videoRef]);
+
   /**
    * Ask for the thumbnail to cover a move to `time` — but only when it would be
    * an improvement on what is already displayed.
@@ -94,24 +148,33 @@ export function useIosScrubPreview({
    */
   const requestPreviewFor = useCallback(
     (time: number) => {
+      // Any pending reveal is now stale — the display is being sent somewhere
+      // else, so a frame presented for the previous target must not uncover the
+      // element.
+      cancelPendingReveal();
+
       setIsPreviewNeeded((wasNeeded) => {
         if (wasNeeded) {
           return true;
         }
-        const landed = lastCommittedVideoTimeRef.current;
-        if (landed === null) {
+        // Compared against the element's live position, not a cached one.
+        // `lastCommittedVideoTimeRef` only advances while `scrubPreviewTimeRef`
+        // is null, which is never true mid-scrub or mid-step, so it goes stale
+        // exactly when this comparison matters — drifting past the thumbnail's
+        // error and making the rule flip-flop, which is what flashed the panel
+        // while a step key was held.
+        const landed = videoRef.current?.currentTime;
+        if (landed === undefined) {
           return true;
         }
         const thumbnail = getNearestPreviewThumbnail(time);
         if (!thumbnail) {
           return false;
         }
-        return (
-          Math.abs(thumbnail.timestamp - time) < Math.abs(landed - time)
-        );
+        return Math.abs(thumbnail.timestamp - time) < Math.abs(landed - time);
       });
     },
-    [getNearestPreviewThumbnail],
+    [cancelPendingReveal, getNearestPreviewThumbnail, videoRef],
   );
 
   const activePreviewFrameSrc = useMemo(() => {
@@ -258,7 +321,7 @@ export function useIosScrubPreview({
           Math.abs(video.currentTime - previewTarget) <= PREVIEW_MATCH_TOLERANCE;
 
         if (hasCaughtUp) {
-          setIsPreviewNeeded(false);
+          revealWhenFramePresented();
         }
 
         if (
@@ -285,11 +348,12 @@ export function useIosScrubPreview({
     return () => {
       video.removeEventListener("seeked", syncSeekTime);
     };
-  }, [updateCurrentTime, videoRef]);
+  }, [revealWhenFramePresented, updateCurrentTime, videoRef]);
 
   // Cleanup all timers/RAFs on unmount.
   useEffect(() => {
     return () => {
+      cancelPendingReveal();
       if (scrubSeekTimeoutRef.current !== null) {
         window.clearTimeout(scrubSeekTimeoutRef.current);
       }
@@ -300,7 +364,7 @@ export function useIosScrubPreview({
         window.clearTimeout(previewSwapTimeoutRef.current);
       }
     };
-  }, []);
+  }, [cancelPendingReveal]);
 
   // Cross-fade swap between displayed and incoming preview frames.
   useEffect(() => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -10,6 +10,7 @@ import {
 
 
 import {
+  PREVIEW_MATCH_TOLERANCE,
   PREVIEW_SWAP_DELAY_MS,
   PreviewThumbnail,
   SCRUB_SEEK_INTERVAL_MS,
@@ -51,6 +52,8 @@ export function useIosScrubPreview({
   const previewSwapTimeoutRef = useRef<number | null>(null);
   const lastCommittedVideoTimeRef = useRef<number | null>(null);
   const activePreviewFrameSrcRef = useRef<string | null>(null);
+  /** The moment the display is trying to represent, wherever the request came from. */
+  const previewTargetTimeRef = useRef<number | null>(null);
 
   const [scrubPreviewTime, setScrubPreviewTime] = useState<number | null>(null);
   const [pausedPreviewTime, setPausedPreviewTime] = useState<number | null>(
@@ -64,27 +67,68 @@ export function useIosScrubPreview({
   >(null);
   const [isIncomingPreviewVisible, setIsIncomingPreviewVisible] =
     useState(false);
+  /**
+   * Whether the thumbnail is still needed.
+   *
+   * Separate from `scrubPreviewTime`, which is where the *pointer* is and must
+   * keep driving the timeline marker for the whole drag. Conflating the two is
+   * why the thumbnail could not be taken down mid-drag: hiding it meant clearing
+   * the pointer position, which would have snapped the marker backwards.
+   */
+  const [isPreviewNeeded, setIsPreviewNeeded] = useState(false);
 
   const getNearestPreviewThumbnail = useCallback(
     (time: number) => findNearestPreviewThumbnail(previewThumbnails, time),
     [previewThumbnails],
   );
 
+  /**
+   * Ask for the thumbnail to cover a move to `time` — but only when it would be
+   * an improvement on what is already displayed.
+   *
+   * Once the real frame is on screen, a small nudge should keep it: the element
+   * is showing a frame a few hundredths of a second away, while the nearest
+   * thumbnail can be half a second off. Swapping to the thumbnail would be a
+   * downgrade, and doing that on every small movement is what would make the
+   * panel strobe between the two sources.
+   */
+  const requestPreviewFor = useCallback(
+    (time: number) => {
+      setIsPreviewNeeded((wasNeeded) => {
+        if (wasNeeded) {
+          return true;
+        }
+        const landed = lastCommittedVideoTimeRef.current;
+        if (landed === null) {
+          return true;
+        }
+        const thumbnail = getNearestPreviewThumbnail(time);
+        if (!thumbnail) {
+          return false;
+        }
+        return (
+          Math.abs(thumbnail.timestamp - time) < Math.abs(landed - time)
+        );
+      });
+    },
+    [getNearestPreviewThumbnail],
+  );
+
   const activePreviewFrameSrc = useMemo(() => {
+    if (!isPreviewNeeded) {
+      return null;
+    }
     const sourceTime = scrubPreviewTime ?? pausedPreviewTime;
-    const selected =
-      sourceTime !== null ? getNearestPreviewThumbnail(sourceTime) : null;
-
-    if (scrubPreviewTime !== null) {
-      return selected?.src ?? null;
+    if (sourceTime === null) {
+      return null;
     }
-
-    if (pausedPreviewTime !== null) {
-      return selected?.src ?? null;
-    }
-
-    return null;
-  }, [getNearestPreviewThumbnail, pausedPreviewTime, scrubPreviewTime]);
+    return getNearestPreviewThumbnail(sourceTime)?.src ?? null;
+  }, [
+    getNearestPreviewThumbnail,
+    isPreviewNeeded,
+    pausedPreviewTime,
+    scrubPreviewTime,
+  ]);
 
   const displayedTimelineTime = scrubPreviewTime ?? currentTime;
   const hasPreviewOverlay =
@@ -96,6 +140,7 @@ export function useIosScrubPreview({
 
   // Reset all preview frame state. Used by bootstrap on video reload and live-photo start.
   const resetPreviewFrames = useCallback(() => {
+    setIsPreviewNeeded(false);
     setDisplayedPreviewFrameSrc(null);
     setIncomingPreviewFrameSrc(null);
     setIsIncomingPreviewVisible(false);
@@ -116,8 +161,10 @@ export function useIosScrubPreview({
       pendingScrubDisplayTimeRef.current = null;
       isScrubPreviewActiveRef.current = false;
       scrubPreviewTimeRef.current = null;
+      previewTargetTimeRef.current = null;
       setScrubPreviewTime(null);
       setPausedPreviewTime(null);
+      setIsPreviewNeeded(false);
       setDisplayedPreviewFrameSrc(null);
       setIncomingPreviewFrameSrc(null);
       setIsIncomingPreviewVisible(false);
@@ -195,6 +242,23 @@ export function useIosScrubPreview({
         if (hasPlayheadSettled && scrubPreviewTimeRef.current !== null) {
           scrubPreviewTimeRef.current = null;
           setScrubPreviewTime(null);
+        }
+
+        // Mid-drag reveal. Nothing further is queued, so this frame is where the
+        // pointer is pointing — and the real element is showing it, while the
+        // thumbnail is a nearest-neighbour guess up to half a second away.
+        // Holding still during a drag now shows the truth rather than saving it
+        // for mouse-up, which is what made the picture change under the worker
+        // just as they decided what to capture.
+        const previewTarget = previewTargetTimeRef.current;
+        const hasCaughtUp =
+          scrubQueuedSeekTimeRef.current === null &&
+          scrubSeekTimeoutRef.current === null &&
+          previewTarget !== null &&
+          Math.abs(video.currentTime - previewTarget) <= PREVIEW_MATCH_TOLERANCE;
+
+        if (hasCaughtUp) {
+          setIsPreviewNeeded(false);
         }
 
         if (
@@ -321,6 +385,8 @@ export function useIosScrubPreview({
       const video = videoRef.current;
       if (!video) return;
       video.pause();
+      previewTargetTimeRef.current = t;
+      requestPreviewFor(t);
       if (scrubPreviewTimeRef.current === null) {
         setPausedPreviewTime(t);
       }
@@ -337,6 +403,7 @@ export function useIosScrubPreview({
     },
     [
       livePhotoEndRef,
+      requestPreviewFor,
       setIsLivePhotoActive,
       syncFocusToTimestamp,
       updateCurrentTime,
@@ -398,6 +465,10 @@ export function useIosScrubPreview({
     scrubDisplayRafRef.current = null;
     const nextTime = pendingScrubDisplayTimeRef.current;
     scrubPreviewTimeRef.current = nextTime;
+    previewTargetTimeRef.current = nextTime;
+    if (nextTime !== null) {
+      requestPreviewFor(nextTime);
+    }
     setScrubPreviewTime(nextTime);
 
     if (nextTime === null || !isScrubPreviewActiveRef.current) {
@@ -405,7 +476,7 @@ export function useIosScrubPreview({
     }
 
     scheduleScrubSeek(nextTime, false, false);
-  }, [scheduleScrubSeek]);
+  }, [requestPreviewFor, scheduleScrubSeek]);
 
   const scheduleScrubDisplayTime = useCallback(
     (time: number | null, immediate: boolean = false) => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-scrub-preview.ts
@@ -196,6 +196,19 @@ export function useIosScrubPreview({
           lastCommittedVideoTimeRef.current = video.currentTime;
           updateCurrentTime(video.currentTime);
         }
+
+        // Reveal the real frame now that the seek has landed. The overlay is
+        // only meant to cover seek latency, but a preview thumbnail is a
+        // nearest-neighbour pick off a coarse grid — roughly 1.2s apart on a
+        // long recording, so up to ~0.6s from the playhead. Leaving it up means
+        // the worker aims with an image that can be half a second stale while
+        // `c` captures the accurate frame underneath it.
+        if (
+          !isScrubPreviewActiveRef.current &&
+          scrubPreviewTimeRef.current === null
+        ) {
+          setPausedPreviewTime(null);
+        }
       });
     };
     video.addEventListener("seeked", syncSeekTime);

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-step-hotkeys.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-step-hotkeys.ts
@@ -13,6 +13,7 @@ interface UseIosStepHotkeysArgs {
   ) => void;
   handleScrubCommit: (time: number) => void;
   setPausedPreviewTime: (time: number | null) => void;
+  onScrubActiveChange: (active: boolean) => void;
 }
 
 /**
@@ -28,11 +29,34 @@ export function useIosStepHotkeys({
   scheduleScrubSeek,
   handleScrubCommit,
   setPausedPreviewTime,
+  onScrubActiveChange,
 }: UseIosStepHotkeysArgs) {
   const stepCommitTimeoutRef = useRef<number | null>(null);
   const steppedTargetTimeRef = useRef<number | null>(null);
+  const isSteppingRef = useRef(false);
 
   useEffect(() => {
+    // Holding a step key is scrubbing by keyboard, so it reports itself as an
+    // active scrub for the duration. Without that, each throttled seek landed
+    // with nothing queued behind it, which reads as "the playhead has settled" —
+    // so the preview was torn down and rebuilt on every repeat, flashing the
+    // video element in and out for as long as the key was held.
+    const beginStepping = () => {
+      if (isSteppingRef.current) {
+        return;
+      }
+      isSteppingRef.current = true;
+      onScrubActiveChange(true);
+    };
+
+    const endStepping = () => {
+      if (!isSteppingRef.current) {
+        return;
+      }
+      isSteppingRef.current = false;
+      onScrubActiveChange(false);
+    };
+
     const flushSteppedTarget = () => {
       if (steppedTargetTimeRef.current === null) {
         return;
@@ -49,6 +73,8 @@ export function useIosStepHotkeys({
       stepCommitTimeoutRef.current = window.setTimeout(() => {
         stepCommitTimeoutRef.current = null;
         flushSteppedTarget();
+        // Idle long enough to count as released, so the reveal can happen.
+        endStepping();
       }, STEP_COMMIT_DELAY_MS);
     };
 
@@ -72,6 +98,7 @@ export function useIosStepHotkeys({
       }
 
       event.preventDefault();
+      beginStepping();
       const delta = event.key === "," ? -FRAME_STEP_SECONDS : FRAME_STEP_SECONDS;
       const baseTime =
         steppedTargetTimeRef.current ??
@@ -96,6 +123,7 @@ export function useIosStepHotkeys({
         stepCommitTimeoutRef.current = null;
       }
       flushSteppedTarget();
+      endStepping();
     };
 
     window.addEventListener("keydown", handleFrameStepKeydown);
@@ -107,6 +135,7 @@ export function useIosStepHotkeys({
   }, [
     currentTimeRef,
     handleScrubCommit,
+    onScrubActiveChange,
     scheduleScrubDisplayTime,
     scheduleScrubSeek,
     scrubPreviewTimeRef,

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
@@ -5,6 +5,7 @@ import { UseFormSetValue } from "react-hook-form";
 import { FrameData, TraceFormData } from "../../../types";
 import { DraftFetchResults } from "../../../../util";
 import { extractThumbnails, extractVideoFrame } from "../../util";
+import { recordPhase } from "./scrub-profiler";
 import {
   MAX_TIMELINE_THUMBS,
   PREVIEW_THUMB_HEIGHT,
@@ -93,6 +94,7 @@ export function useIosVideoBootstrap({
       if (draftFetchResult === DraftFetchResults.LOADING) {
         return;
       }
+      const bootstrapStartedAt = performance.now();
       try {
         isProcessingRef.current = true;
         setIsVideoReady(false);
@@ -136,6 +138,7 @@ export function useIosVideoBootstrap({
         if (video.duration === 0) {
           throw new Error("Video duration not available");
         }
+        const timelineThumbsStartedAt = performance.now();
         const thumbs = await extractThumbnails(
           video,
           video.duration,
@@ -148,10 +151,13 @@ export function useIosVideoBootstrap({
             preferOffscreenCanvas: true,
           },
         );
+        recordPhase("timelineThumbnails", performance.now() - timelineThumbsStartedAt);
         thumbnailObjectUrlsRef.current = thumbs
           .map((thumb) => thumb.src)
           .filter((src) => src.startsWith("blob:"));
         setThumbnails(thumbs);
+        // The phase that disappears if the preview pipeline is removed.
+        const previewThumbsStartedAt = performance.now();
         const largePreviewThumbs = await extractThumbnails(
           video,
           video.duration,
@@ -164,6 +170,11 @@ export function useIosVideoBootstrap({
             preferOffscreenCanvas: true,
           },
         );
+        recordPhase(
+          "previewThumbnails",
+          performance.now() - previewThumbsStartedAt,
+        );
+        recordPhase("previewThumbnailCount", largePreviewThumbs.length);
         previewThumbnailObjectUrlsRef.current = largePreviewThumbs
           .map((thumb) => thumb.src)
           .filter((src) => src.startsWith("blob:"));
@@ -203,6 +214,7 @@ export function useIosVideoBootstrap({
           "screens",
           draftScreens.sort((a, b) => a.timestamp - b.timestamp),
         );
+        recordPhase("bootstrapTotal", performance.now() - bootstrapStartedAt);
         // Done seeking the live element. Anything holding a playhead position
         // can place it now without bootstrap dragging it away.
         setIsVideoReady(true);

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
@@ -58,6 +58,11 @@ export function useIosVideoBootstrap({
   const thumbnailObjectUrlsRef = useRef<string[]>([]);
   const previewThumbnailObjectUrlsRef = useRef<string[]>([]);
   const isProcessingRef = useRef(false);
+  /**
+   * Identifies the current bootstrap run, so work deferred past the interactive
+   * phase can tell whether it is still wanted.
+   */
+  const bootstrapRunIdRef = useRef(0);
 
   const [videoDuration, setVideoDuration] = useState(0);
   const [isVideoReady, setIsVideoReady] = useState(false);
@@ -84,6 +89,7 @@ export function useIosVideoBootstrap({
   // Bootstrap effect: load the video, extract thumbnails + preview thumbnails,
   // and populate any screens missing a frame image.
   useEffect(() => {
+    const runId = bootstrapRunIdRef.current;
     const loadVideoAndPopulate = async () => {
       if (isProcessingRef.current) {
         return;
@@ -95,6 +101,9 @@ export function useIosVideoBootstrap({
         return;
       }
       const bootstrapStartedAt = performance.now();
+      // Captured for the deferred phase below, which runs outside the try block.
+      let video: HTMLVideoElement;
+      let duration: number;
       try {
         isProcessingRef.current = true;
         setIsVideoReady(false);
@@ -105,7 +114,7 @@ export function useIosVideoBootstrap({
         setThumbnails([]);
         setPreviewThumbnails([]);
         onResetPreviewFrames();
-        const video = videoRef.current;
+        video = videoRef.current;
         video.src = videoFiles[0].fileUrl;
         await new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => {
@@ -138,6 +147,7 @@ export function useIosVideoBootstrap({
         if (video.duration === 0) {
           throw new Error("Video duration not available");
         }
+        duration = video.duration;
         const timelineThumbsStartedAt = performance.now();
         const thumbs = await extractThumbnails(
           video,
@@ -156,29 +166,6 @@ export function useIosVideoBootstrap({
           .map((thumb) => thumb.src)
           .filter((src) => src.startsWith("blob:"));
         setThumbnails(thumbs);
-        // The phase that disappears if the preview pipeline is removed.
-        const previewThumbsStartedAt = performance.now();
-        const largePreviewThumbs = await extractThumbnails(
-          video,
-          video.duration,
-          Math.min(90, Math.max(52, Math.ceil(video.duration))),
-          PREVIEW_THUMB_HEIGHT,
-          {
-            mimeType: "image/jpeg",
-            quality: PREVIEW_THUMB_JPEG_QUALITY,
-            output: "object-url",
-            preferOffscreenCanvas: true,
-          },
-        );
-        recordPhase(
-          "previewThumbnails",
-          performance.now() - previewThumbsStartedAt,
-        );
-        recordPhase("previewThumbnailCount", largePreviewThumbs.length);
-        previewThumbnailObjectUrlsRef.current = largePreviewThumbs
-          .map((thumb) => thumb.src)
-          .filter((src) => src.startsWith("blob:"));
-        setPreviewThumbnails(largePreviewThumbs);
         const screensSnapshot = screensRef.current.map((screen) => ({
           ...screen,
         }));
@@ -221,11 +208,64 @@ export function useIosVideoBootstrap({
       } catch (e) {
         console.error("Error loading video blob:", e);
         toast.error("Error loading video for frame extraction");
+        return;
       } finally {
         isProcessingRef.current = false;
       }
+
+      // Scrub-preview thumbnails, deliberately after the step is interactive.
+      //
+      // Nothing on screen needs them: with an empty grid the preview overlay
+      // never renders and scrubbing falls through to real video frames, which
+      // measured at 14-38ms median across Chrome and Safari. Blocking on this
+      // was between a third and a half of the wait to enter the step.
+      //
+      // Extraction runs on its own cloned element, so it cannot disturb the
+      // playhead — but it does compete for decode bandwidth, so seeks in the
+      // first seconds may be slower than once it has finished.
+      if (bootstrapRunIdRef.current !== runId) {
+        return;
+      }
+      try {
+        const previewThumbsStartedAt = performance.now();
+        const largePreviewThumbs = await extractThumbnails(
+          video,
+          duration,
+          Math.min(90, Math.max(52, Math.ceil(duration))),
+          PREVIEW_THUMB_HEIGHT,
+          {
+            mimeType: "image/jpeg",
+            quality: PREVIEW_THUMB_JPEG_QUALITY,
+            output: "object-url",
+            preferOffscreenCanvas: true,
+          },
+        );
+        // The worker may have left the step while this ran. Its blob URLs are
+        // not in the ref yet, so the unmount sweep cannot see them.
+        if (bootstrapRunIdRef.current !== runId) {
+          revokeBlobUrls(largePreviewThumbs.map((thumb) => thumb.src));
+          return;
+        }
+        recordPhase(
+          "previewThumbnails",
+          performance.now() - previewThumbsStartedAt,
+        );
+        recordPhase("previewThumbnailCount", largePreviewThumbs.length);
+        previewThumbnailObjectUrlsRef.current = largePreviewThumbs
+          .map((thumb) => thumb.src)
+          .filter((src) => src.startsWith("blob:"));
+        setPreviewThumbnails(largePreviewThumbs);
+      } catch (error) {
+        // Scrubbing keeps working on real frames, so this is not worth a toast.
+        console.error(`Error extracting scrub preview thumbnails: ${error}`);
+      }
     };
     loadVideoAndPopulate();
+    return () => {
+      // Invalidate the run so deferred extraction stops and cleans up after
+      // itself if the worker leaves the step.
+      bootstrapRunIdRef.current += 1;
+    };
   }, [
     draftFetchResult,
     onResetPreviewFrames,

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
@@ -256,8 +256,13 @@ export function useIosVideoBootstrap({
           .filter((src) => src.startsWith("blob:"));
         setPreviewThumbnails(largePreviewThumbs);
       } catch (error) {
-        // Scrubbing keeps working on real frames, so this is not worth a toast.
+        // Worth a toast after all. The previous note here reasoned that scrubbing
+        // still falls back to real frames, which is true — but the worker loses
+        // every preview during a drag and is given no reason for it. That state
+        // had to be diagnosed from behaviour once already, because a console
+        // error is silence to anyone not holding devtools open.
         console.error(`Error extracting scrub preview thumbnails: ${error}`);
+        toast.error("Scrub previews unavailable — scrubbing still works");
       }
     };
     loadVideoAndPopulate();

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-bootstrap.ts
@@ -171,6 +171,16 @@ export function useIosVideoBootstrap({
         }));
         const draftScreens: FrameData[] = [];
 
+        // Every failure below is contained to the one frame it affects, and the
+        // screen is kept either way.
+        //
+        // This used to be a single try around the whole loop, with the list
+        // written to form state afterwards — so one failed read left the list
+        // truncated at that screen, and a failed warm-up left it empty. Autosave
+        // runs every three minutes and writes form state without checking it, so
+        // the truncated list would go over the worker's draft and take the rest
+        // of their annotation work with it, reporting "Draft autosaved" while
+        // doing so.
         try {
           // Warm the video decoder once before extracting any missing frames.
           const warmupFrame = await extractVideoFrame(video, 0.1, {
@@ -181,8 +191,16 @@ export function useIosVideoBootstrap({
           if (warmupFrame.src.startsWith("blob:")) {
             URL.revokeObjectURL(warmupFrame.src);
           }
-          for (const screen of screensSnapshot) {
-            if (!screen.src) {
+        } catch (error) {
+          // Only a warm-up. The reads below may still succeed, and none of this
+          // is worth a screen.
+          console.error(`Could not warm the video decoder: ${error}`);
+        }
+
+        let unrebuiltScreenCount = 0;
+        for (const screen of screensSnapshot) {
+          if (!screen.src) {
+            try {
               const frame = await extractVideoFrame(video, screen.timestamp, {
                 mimeType: "image/png",
                 output: "object-url",
@@ -190,11 +208,23 @@ export function useIosVideoBootstrap({
               });
               screen.src = frame.src;
               registerScreenUrl(frame.src);
+            } catch (error) {
+              // Keep the screen regardless. Its timestamp is the record of where
+              // the worker marked something, and its id keys the gestures and
+              // redactions they have already written — dropping it discards all
+              // of that to save an image that can be re-extracted.
+              unrebuiltScreenCount += 1;
+              console.error(
+                `Could not rebuild the image for screen ${screen.id}: ${error}`,
+              );
             }
-            draftScreens.push(screen);
           }
-        } catch (error) {
-          console.error(`Error extracting video frames: ${error}`);
+          draftScreens.push(screen);
+        }
+        if (unrebuiltScreenCount > 0) {
+          toast.error(
+            `${unrebuiltScreenCount} of ${screensSnapshot.length} screens could not be rebuilt from the recording. Their annotations are intact.`,
+          );
         }
 
         setValue(

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-playback.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/use-ios-video-playback.ts
@@ -3,14 +3,14 @@ import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 interface UseIosVideoPlaybackArgs {
   videoRef: RefObject<HTMLVideoElement | null>;
   videoDuration: number;
-  focusViewIndex: number;
+  focusedScreenId: string | null;
   onLivePhotoStart?: () => void;
 }
 
 export function useIosVideoPlayback({
   videoRef,
   videoDuration,
-  focusViewIndex,
+  focusedScreenId,
   onLivePhotoStart,
 }: UseIosVideoPlaybackArgs) {
   const rafRef = useRef<number>(0);
@@ -53,7 +53,7 @@ export function useIosVideoPlayback({
   useEffect(() => {
     livePhotoEndRef.current = null;
     setIsLivePhotoActive(false);
-  }, [focusViewIndex]);
+  }, [focusedScreenId]);
 
   const handlePlayPause = useCallback(async () => {
     const video = videoRef.current;

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/video-preview-overlay.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/video-preview-overlay.tsx
@@ -25,14 +25,18 @@ export function VideoPreviewOverlay({
 }: VideoPreviewOverlayProps) {
   return (
     <div className="relative flex justify-center items-center w-full h-full">
+      {/*
+        Always painted. The preview images stack on top and cover it, so hiding
+        it was never necessary — and toggling opacity on a video forces a
+        compositor layer change, which showed up as a blip each time the overlay
+        came down. Leaving it composited means uncovering it is just the image
+        above it going away.
+      */}
       <video
         ref={videoRef}
         crossOrigin="anonymous"
         preload="auto"
-        className={cn(
-          "relative z-0 max-w-full max-h-full rounded-lg object-contain transition-opacity",
-          hasPreviewOverlay ? "opacity-0" : "opacity-100",
-        )}
+        className="relative z-0 max-w-full max-h-full rounded-lg object-contain"
         controls={false}
         onPlay={onPlay}
         onPause={onPause}

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/video-preview-overlay.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/components/ios/video-preview-overlay.tsx
@@ -62,6 +62,21 @@ export function VideoPreviewOverlay({
           )}
         />
       ) : null}
+      {/*
+        Preview frames come from a coarse thumbnail grid — roughly a second apart
+        on a long recording — so what is showing here can sit up to half a second
+        from the playhead. Labelling it means the correction when the real frame
+        arrives reads as the picture sharpening rather than the tool changing its
+        mind, and it marks the moments when `c` would capture something other
+        than what is on screen.
+      */}
+      {hasPreviewOverlay ? (
+        <div className="pointer-events-none absolute left-1/2 top-3 z-30 -translate-x-1/2">
+          <span className="inline-flex items-center rounded-md border border-black/15 bg-black/55 px-2 py-1 text-[11px] font-semibold tracking-wide text-white shadow-sm dark:border-white/25 dark:bg-white/90 dark:text-black">
+            Preview
+          </span>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
@@ -127,8 +127,8 @@ export default function RepairScreen({
   );
 
   // Navigation is deliberately unguarded. Gesture completeness is enforced
-  // where it can actually hold — the step's Next button validates every screen
-  // against ScreenGestureSchema and reports each failure (page.tsx). Blocking
+  // where it can actually hold — the step gates in page.tsx check every screen
+  // and name each one that needs work. Blocking
   // Tab/arrows only trapped keyboard users: it was silent, one-directional
   // (Previous was always free), and bypassed by clicking a filmstrip item or a
   // feedback chip, so it enforced nothing while making the keyboard feel broken

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
@@ -26,6 +26,12 @@ export interface RepairScreenJumpTarget {
   screenId: string;
 }
 
+/**
+ * Stable fallback for the watched screens list. A fresh `[]` literal would
+ * change identity every render and defeat every dependency array that reads it.
+ */
+const EMPTY_SCREENS: FrameData[] = [];
+
 interface NavigationContextType {
   handleNext: () => void;
   handlePrevious: () => void;
@@ -93,14 +99,12 @@ export default function RepairScreen({
   jumpTarget?: RepairScreenJumpTarget | null;
 }) {
   const { getValues, setValue } = useFormContext<TraceFormData>();
-  const [watchScreens, watchGestures] = useWatch({
-    name: ["screens", "gestures"],
-  });
-  const screens = watchScreens as FrameData[];
-  const gestures = useMemo(
-    () => (watchGestures ?? {}) as { [key: string]: ScreenGesture },
-    [watchGestures],
-  );
+  // Only `screens` is watched. Dropping the `gestures` subscription keeps this
+  // component from re-rendering on every keystroke in the annotation editor —
+  // react-hook-form hands out a deep clone of the form on each write, which is
+  // what made the jump effect re-fire per keystroke in the first place.
+  const screens = (useWatch({ name: "screens" }) ??
+    EMPTY_SCREENS) as FrameData[];
 
   const os = capture?.task ? capture.task.os : "none";
   const [focusedScreenId, setFocusedScreenId] = useState<string | null>(null);
@@ -122,23 +126,14 @@ export default function RepairScreen({
     [],
   );
 
-  // UI-level guard for keyboard/arrow navigation so users cannot leave a screen
-  // with incomplete required template fields. Matches validateGestureDescription
-  // used by filmstrip and form schema.
-  const canAdvanceFromCurrentScreen = useCallback(() => {
-    if (focusedIndex < 0 || focusedIndex >= screens.length) {
-      return true;
-    }
-    // Last screen does not require a gesture.
-    if (focusedIndex === screens.length - 1) {
-      return true;
-    }
-    const currentScreen = screens[focusedIndex];
-    const currentGesture = gestures[currentScreen.id];
-    return validateGestureDescription(
-      currentGesture ?? { type: null, description: "" },
-    );
-  }, [focusedIndex, gestures, screens]);
+  // Navigation is deliberately unguarded. Gesture completeness is enforced
+  // where it can actually hold — the step's Next button validates every screen
+  // against ScreenGestureSchema and reports each failure (page.tsx). Blocking
+  // Tab/arrows only trapped keyboard users: it was silent, one-directional
+  // (Previous was always free), and bypassed by clicking a filmstrip item or a
+  // feedback chip, so it enforced nothing while making the keyboard feel broken
+  // — you could not even reach a newly captured screen without first filling in
+  // every incomplete screen ahead of it.
 
   // handle focusing on previous screen in the filmstrip list
   const handlePrevious = useCallback(() => {
@@ -158,12 +153,9 @@ export default function RepairScreen({
     if (screens.length === 0) {
       return;
     }
-    if (!canAdvanceFromCurrentScreen()) {
-      return;
-    }
     const wrappedIndex = (focusedIndex + 1) % screens.length;
     setFocusedScreenId(screens[wrappedIndex].id);
-  }, [canAdvanceFromCurrentScreen, focusedIndex, screens]);
+  }, [focusedIndex, screens]);
 
   const handleDeleteScreen = useCallback(
     (screenId: string) => {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
@@ -29,9 +29,20 @@ export interface RepairScreenJumpTarget {
 interface NavigationContextType {
   handleNext: () => void;
   handlePrevious: () => void;
-  handleDeleteScreen: (index: number) => void;
-  focusViewIndex: number;
-  setFocusViewIndex: (index: number) => void;
+  handleDeleteScreen: (screenId: string) => void;
+  /**
+   * The focused screen, identified by id. Authoritative — inserting or deleting
+   * a screen shifts positions, so an index cannot survive an edit to the trace.
+   */
+  focusedScreenId: string | null;
+  setFocusedScreenId: (screenId: string | null) => void;
+  /**
+   * Position of the focused screen in the sorted list, derived from
+   * `focusedScreenId`. Provided here so ordering questions ("is this the last
+   * screen?", "what is next?") have one answer rather than one per consumer.
+   * `-1` when nothing is focused or the focused screen no longer exists.
+   */
+  focusedIndex: number;
   /**
    * Lets a platform with a scrubbable recording hand up a seek function, so an
    * explicit jump to a screen can move the playhead with it. Pass `null` to
@@ -92,7 +103,14 @@ export default function RepairScreen({
   );
 
   const os = capture?.task ? capture.task.os : "none";
-  const [focusViewIndex, setFocusViewIndex] = useState<number>(-1);
+  const [focusedScreenId, setFocusedScreenId] = useState<string | null>(null);
+  const focusedIndex = useMemo(
+    () =>
+      focusedScreenId === null
+        ? -1
+        : screens.findIndex((screen) => screen.id === focusedScreenId),
+    [focusedScreenId, screens],
+  );
 
   // Held in a ref rather than state: registering a seek function must not
   // re-render, and the jump effect only ever reads the current one.
@@ -108,19 +126,19 @@ export default function RepairScreen({
   // with incomplete required template fields. Matches validateGestureDescription
   // used by filmstrip and form schema.
   const canAdvanceFromCurrentScreen = useCallback(() => {
-    if (focusViewIndex < 0 || focusViewIndex >= screens.length) {
+    if (focusedIndex < 0 || focusedIndex >= screens.length) {
       return true;
     }
     // Last screen does not require a gesture.
-    if (focusViewIndex === screens.length - 1) {
+    if (focusedIndex === screens.length - 1) {
       return true;
     }
-    const currentScreen = screens[focusViewIndex];
+    const currentScreen = screens[focusedIndex];
     const currentGesture = gestures[currentScreen.id];
     return validateGestureDescription(
       currentGesture ?? { type: null, description: "" },
     );
-  }, [focusViewIndex, gestures, screens]);
+  }, [focusedIndex, gestures, screens]);
 
   // handle focusing on previous screen in the filmstrip list
   const handlePrevious = useCallback(() => {
@@ -128,12 +146,12 @@ export default function RepairScreen({
       return;
     }
     // javascript be stupid, negative modulo isn't a thing here
-    let wrappedIndex = (focusViewIndex - 1) % screens.length;
+    let wrappedIndex = (focusedIndex - 1) % screens.length;
     if (wrappedIndex < 0) {
       wrappedIndex = screens.length - 1;
     }
-    setFocusViewIndex(wrappedIndex);
-  }, [focusViewIndex, screens.length]);
+    setFocusedScreenId(screens[wrappedIndex].id);
+  }, [focusedIndex, screens]);
 
   // handle focusing on next screen in the filmstrip list
   const handleNext = useCallback(() => {
@@ -143,14 +161,17 @@ export default function RepairScreen({
     if (!canAdvanceFromCurrentScreen()) {
       return;
     }
-    const wrappedIndex = (focusViewIndex + 1) % screens.length;
-    setFocusViewIndex(wrappedIndex);
-  }, [canAdvanceFromCurrentScreen, focusViewIndex, screens.length]);
+    const wrappedIndex = (focusedIndex + 1) % screens.length;
+    setFocusedScreenId(screens[wrappedIndex].id);
+  }, [canAdvanceFromCurrentScreen, focusedIndex, screens]);
 
   const handleDeleteScreen = useCallback(
-    (index: number) => {
+    (screenId: string) => {
       const currentScreens = getValues("screens");
-      if (index < 0 || index >= currentScreens.length) {
+      const index = currentScreens.findIndex(
+        (screen) => screen.id === screenId,
+      );
+      if (index < 0) {
         return;
       }
 
@@ -176,7 +197,7 @@ export default function RepairScreen({
       setValue("gestures", nextGestures);
       setValue("redactions", nextRedactions);
       setValue("vhs", nextVHs);
-      setFocusViewIndex(-1);
+      setFocusedScreenId(null);
     },
     [getValues, setValue],
   );
@@ -212,15 +233,18 @@ export default function RepairScreen({
     "backspace",
     (event) => {
       event.preventDefault();
-      handleDeleteScreen(focusViewIndex);
+      if (focusedScreenId === null) {
+        return;
+      }
+      handleDeleteScreen(focusedScreenId);
     },
     {
-      enabled: focusViewIndex >= 0,
+      enabled: focusedScreenId !== null,
       enableOnFormTags: false,
       enableOnContentEditable: false,
       preventDefault: true,
     },
-    [focusViewIndex, handleDeleteScreen],
+    [focusedScreenId, handleDeleteScreen],
   );
 
   // A checklist jump must apply exactly once per click. `screens` stays in the
@@ -244,7 +268,7 @@ export default function RepairScreen({
     );
     if (targetIndex >= 0) {
       appliedJumpNonceRef.current = jumpTarget.nonce;
-      setFocusViewIndex(targetIndex);
+      setFocusedScreenId(jumpTarget.screenId);
       // Move the recording to the same screen, matching what clicking the
       // filmstrip already does. Without this the playhead stays where it was,
       // and `c` would capture a frame from an unrelated part of the video —
@@ -259,8 +283,9 @@ export default function RepairScreen({
         handleNext,
         handlePrevious,
         handleDeleteScreen,
-        focusViewIndex,
-        setFocusViewIndex,
+        focusedScreenId,
+        setFocusedScreenId,
+        focusedIndex,
         registerSeekToTime,
       }}
     >

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/repair-screen.tsx
@@ -16,10 +16,9 @@ import { FrameData, TraceFormData } from "../types";
 import { useHotkeys } from "react-hotkeys-hook";
 import { RepairScreenAndroid } from "./components/android/repair-screen-android";
 import { RepairScreenIOS } from "./components/ios/repair-screen-ios";
-import { Prisma, ScreenGesture } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import { DraftFetchResults } from "../../util";
 import { ListedFiles } from "@/lib/actions";
-import { validateGestureDescription } from "./util";
 
 export interface RepairScreenJumpTarget {
   nonce: number;
@@ -32,6 +31,46 @@ export interface RepairScreenJumpTarget {
  */
 const EMPTY_SCREENS: FrameData[] = [];
 
+/**
+ * What caused a screen to be selected. Determines whether the recording follows,
+ * so that policy lives in one readable place instead of being spread across call
+ * sites — which is how the filmstrip ended up seeking one way and the feedback
+ * checklist another.
+ */
+export type SelectScreenSource =
+  /** A feedback checklist chip. Explicitly "take me to this screen". */
+  | "jump"
+  /** A click on a filmstrip thumbnail. Also explicit. */
+  | "filmstrip"
+  /** Tab or the arrow keys, stepping through screens while annotating. */
+  | "keyboard"
+  /** A frame the worker just captured. */
+  | "capture"
+  /** The selected screen was removed, so nothing is selected. */
+  | "delete"
+  /** Derived from the playhead — the recording moved first, so it must not move again. */
+  | "playhead";
+
+/**
+ * Sources that carry the recording to the selected screen.
+ *
+ * Deliberately excludes `keyboard`: workers tab through screens quickly while
+ * annotating, and seeking on every step would churn the video and its preview
+ * frames. Excludes `capture` because the playhead is already there, and
+ * `playhead` because that selection came *from* the recording — moving it again
+ * is the feedback loop that let a click land on a neighbouring screen.
+ */
+const SOURCES_THAT_MOVE_PLAYHEAD: ReadonlySet<SelectScreenSource> = new Set([
+  "jump",
+  "filmstrip",
+]);
+
+/** A request to place the recording's playhead, applied once per nonce. */
+export interface PlayheadRequest {
+  time: number;
+  nonce: number;
+}
+
 interface NavigationContextType {
   handleNext: () => void;
   handlePrevious: () => void;
@@ -41,7 +80,11 @@ interface NavigationContextType {
    * a screen shifts positions, so an index cannot survive an edit to the trace.
    */
   focusedScreenId: string | null;
-  setFocusedScreenId: (screenId: string | null) => void;
+  /**
+   * Focus a screen, declaring why. The reason decides whether the recording
+   * follows; see `SOURCES_THAT_MOVE_PLAYHEAD`.
+   */
+  selectScreen: (screenId: string | null, source: SelectScreenSource) => void;
   /**
    * Position of the focused screen in the sorted list, derived from
    * `focusedScreenId`. Provided here so ordering questions ("is this the last
@@ -50,11 +93,14 @@ interface NavigationContextType {
    */
   focusedIndex: number;
   /**
-   * Lets a platform with a scrubbable recording hand up a seek function, so an
-   * explicit jump to a screen can move the playhead with it. Pass `null` to
-   * unregister. Android has no recording to scrub and never registers.
+   * Where the recording has been asked to sit, or `null` if nothing has asked.
+   *
+   * Desired state rather than an imperative call: a platform that owns a
+   * recording reconciles towards it whenever it is able to, so a request made
+   * while the video is still loading is applied when loading finishes instead of
+   * being lost. Platforms without a recording ignore it.
    */
-  registerSeekToTime: (seek: ((timestamp: number) => void) | null) => void;
+  playheadRequest: PlayheadRequest | null;
 }
 
 const NavigationContext = createContext<NavigationContextType | undefined>(
@@ -108,6 +154,9 @@ export default function RepairScreen({
 
   const os = capture?.task ? capture.task.os : "none";
   const [focusedScreenId, setFocusedScreenId] = useState<string | null>(null);
+  const [playheadRequest, setPlayheadRequest] =
+    useState<PlayheadRequest | null>(null);
+  const playheadNonceRef = useRef(0);
   const focusedIndex = useMemo(
     () =>
       focusedScreenId === null
@@ -116,14 +165,31 @@ export default function RepairScreen({
     [focusedScreenId, screens],
   );
 
-  // Held in a ref rather than state: registering a seek function must not
-  // re-render, and the jump effect only ever reads the current one.
-  const seekToTimeRef = useRef<((timestamp: number) => void) | null>(null);
-  const registerSeekToTime = useCallback(
-    (seek: ((timestamp: number) => void) | null) => {
-      seekToTimeRef.current = seek;
+  /**
+   * Every selection goes through here, so "does the recording follow?" is
+   * answered once, from the reason, rather than at each call site.
+   */
+  const selectScreen = useCallback(
+    (screenId: string | null, source: SelectScreenSource) => {
+      setFocusedScreenId(screenId);
+
+      if (screenId === null || !SOURCES_THAT_MOVE_PLAYHEAD.has(source)) {
+        return;
+      }
+      const screen = screens.find((candidate) => candidate.id === screenId);
+      if (!screen) {
+        return;
+      }
+      // A nonce rather than the timestamp alone: re-selecting the same screen has
+      // to re-place the playhead, and the value has to differ for the reconciler
+      // to notice.
+      playheadNonceRef.current += 1;
+      setPlayheadRequest({
+        time: screen.timestamp,
+        nonce: playheadNonceRef.current,
+      });
     },
-    [],
+    [screens],
   );
 
   // Navigation is deliberately unguarded. Gesture completeness is enforced
@@ -145,8 +211,8 @@ export default function RepairScreen({
     if (wrappedIndex < 0) {
       wrappedIndex = screens.length - 1;
     }
-    setFocusedScreenId(screens[wrappedIndex].id);
-  }, [focusedIndex, screens]);
+    selectScreen(screens[wrappedIndex].id, "keyboard");
+  }, [focusedIndex, screens, selectScreen]);
 
   // handle focusing on next screen in the filmstrip list
   const handleNext = useCallback(() => {
@@ -154,8 +220,8 @@ export default function RepairScreen({
       return;
     }
     const wrappedIndex = (focusedIndex + 1) % screens.length;
-    setFocusedScreenId(screens[wrappedIndex].id);
-  }, [focusedIndex, screens]);
+    selectScreen(screens[wrappedIndex].id, "keyboard");
+  }, [focusedIndex, screens, selectScreen]);
 
   const handleDeleteScreen = useCallback(
     (screenId: string) => {
@@ -189,9 +255,9 @@ export default function RepairScreen({
       setValue("gestures", nextGestures);
       setValue("redactions", nextRedactions);
       setValue("vhs", nextVHs);
-      setFocusedScreenId(null);
+      selectScreen(null, "delete");
     },
-    [getValues, setValue],
+    [getValues, selectScreen, setValue],
   );
 
   useHotkeys(
@@ -255,19 +321,17 @@ export default function RepairScreen({
       return;
     }
 
-    const targetIndex = screens.findIndex(
+    const targetScreen = screens.find(
       (screen) => screen.id === jumpTarget.screenId,
     );
-    if (targetIndex >= 0) {
+    if (targetScreen) {
       appliedJumpNonceRef.current = jumpTarget.nonce;
-      setFocusedScreenId(jumpTarget.screenId);
-      // Move the recording to the same screen, matching what clicking the
-      // filmstrip already does. Without this the playhead stays where it was,
-      // and `c` would capture a frame from an unrelated part of the video —
-      // which is exactly what the feedback often asks the worker to do.
-      seekToTimeRef.current?.(screens[targetIndex].timestamp);
+      // "jump" carries the recording with it, so the worker lands on the screen
+      // *and* the moment it came from — `c` would otherwise capture a frame from
+      // wherever the playhead was left.
+      selectScreen(targetScreen.id, "jump");
     }
-  }, [jumpTarget, screens]);
+  }, [jumpTarget, screens, selectScreen]);
 
   return (
     <NavigationProvider
@@ -276,9 +340,9 @@ export default function RepairScreen({
         handlePrevious,
         handleDeleteScreen,
         focusedScreenId,
-        setFocusedScreenId,
+        selectScreen,
         focusedIndex,
-        registerSeekToTime,
+        playheadRequest,
       }}
     >
       {(os.toLowerCase() as Platform) === Platform.ANDROID ? (

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/gesture-description-template.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/gesture-description-template.ts
@@ -311,28 +311,53 @@ export function validateGestureDescription(
   });
 }
 
+/** The reason a screen's annotation is not finished yet. */
+export type ScreenAnnotationIssue =
+  | "missing-gesture"
+  | "missing-type"
+  | "missing-marker"
+  | "incomplete-drag"
+  | "incomplete-description";
+
+/** What the worker has to do about each issue, phrased as an instruction. */
+export const SCREEN_ANNOTATION_ISSUE_ACTIONS: Record<
+  ScreenAnnotationIssue,
+  string
+> = {
+  "missing-gesture": "add a gesture",
+  "missing-type": "choose a gesture type",
+  "missing-marker": "place the gesture on the screen",
+  "incomplete-drag": "add the drag end point",
+  "incomplete-description": "finish the description",
+};
+
+type GestureCompletenessFields = Pick<
+  ScreenGesture,
+  "type" | "description" | "x" | "y" | "scrollDeltaX" | "scrollDeltaY"
+>;
+
 /**
- * Whether a screen's annotation is finished: a gesture exists, it is placed
- * somewhere on the screen, and its description satisfies the template.
+ * Why a screen's annotation is unfinished, or `null` when it is done.
  *
  * Single source of truth for "is this screen done", shared by the filmstrip's
- * error ring and the step's Next gate so the two cannot disagree — previously
- * the ring ignored marker placement while the gate required it, so a screen
- * could look complete and still block the step.
+ * error ring and the step's Next gate so the two cannot disagree — the ring used
+ * to ignore marker placement while the gate required it, so a screen could look
+ * finished and still block the step. Returning the reason rather than a boolean
+ * lets the gate say what is wrong instead of only which screens are wrong.
+ *
+ * Checks run most-basic-first so the reported reason is the one the worker
+ * should act on next.
  *
  * @param gesture - The gesture recorded for a screen, if any.
  */
-export function isScreenAnnotationComplete(
-  gesture:
-    | Pick<
-        ScreenGesture,
-        "type" | "description" | "x" | "y" | "scrollDeltaX" | "scrollDeltaY"
-      >
-    | null
-    | undefined,
-): boolean {
+export function getScreenAnnotationIssue(
+  gesture: GestureCompletenessFields | null | undefined,
+): ScreenAnnotationIssue | null {
   if (!gesture) {
-    return false;
+    return "missing-gesture";
+  }
+  if (!gesture.type) {
+    return "missing-type";
   }
   // validateGestureDescription covers type, template slots and drag end-points,
   // but not whether the marker was ever placed.
@@ -342,9 +367,29 @@ export function isScreenAnnotationComplete(
     gesture.y === null ||
     gesture.y === undefined
   ) {
-    return false;
+    return "missing-marker";
   }
-  return validateGestureDescription(gesture);
+  if (
+    normalizeGestureType(gesture.type) === GESTURE_TYPES.DRAG &&
+    !hasCompleteDragPoints(gesture)
+  ) {
+    return "incomplete-drag";
+  }
+  if (!validateGestureDescription(gesture)) {
+    return "incomplete-description";
+  }
+  return null;
+}
+
+/**
+ * Whether a screen's annotation is finished.
+ *
+ * @param gesture - The gesture recorded for a screen, if any.
+ */
+export function isScreenAnnotationComplete(
+  gesture: GestureCompletenessFields | null | undefined,
+): boolean {
+  return getScreenAnnotationIssue(gesture) === null;
 }
 
 export function hasCompleteDragPoints(

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/gesture-description-template.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/gesture-description-template.ts
@@ -311,6 +311,42 @@ export function validateGestureDescription(
   });
 }
 
+/**
+ * Whether a screen's annotation is finished: a gesture exists, it is placed
+ * somewhere on the screen, and its description satisfies the template.
+ *
+ * Single source of truth for "is this screen done", shared by the filmstrip's
+ * error ring and the step's Next gate so the two cannot disagree — previously
+ * the ring ignored marker placement while the gate required it, so a screen
+ * could look complete and still block the step.
+ *
+ * @param gesture - The gesture recorded for a screen, if any.
+ */
+export function isScreenAnnotationComplete(
+  gesture:
+    | Pick<
+        ScreenGesture,
+        "type" | "description" | "x" | "y" | "scrollDeltaX" | "scrollDeltaY"
+      >
+    | null
+    | undefined,
+): boolean {
+  if (!gesture) {
+    return false;
+  }
+  // validateGestureDescription covers type, template slots and drag end-points,
+  // but not whether the marker was ever placed.
+  if (
+    gesture.x === null ||
+    gesture.x === undefined ||
+    gesture.y === null ||
+    gesture.y === undefined
+  ) {
+    return false;
+  }
+  return validateGestureDescription(gesture);
+}
+
 export function hasCompleteDragPoints(
   gesture: Pick<ScreenGesture, "x" | "y" | "scrollDeltaX" | "scrollDeltaY">,
 ): boolean {

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
@@ -40,20 +40,34 @@ const resolveExtractOptions = (
 };
 
 /**
- * How long to wait for a seek to report back before drawing anyway.
+ * How often to check whether a seek that has not reported back is real.
  *
  * Asking for the position the element already holds may complete without firing
  * `seeked` at all, and an unbounded wait there hangs the caller for good —
- * capturing at the current playhead is exactly that case. Falling through is safe
- * precisely when it happens, because the frame on the element is already the one
- * being asked for.
+ * capturing at the current playhead is exactly that case.
  *
- * Deliberately a deadline rather than a `video.seeking` check. Skipping the wait
- * whenever `seeking` reads false would draw before the frame arrives on any engine
- * that sets the flag asynchronously, which trades a hang for a wrong frame — the
- * far worse of the two, and the failure this whole area has already been bitten by.
+ * The check is `video.seeking`, but taken at this interval rather than
+ * immediately. Read at once it is worthless — engines may not have set the flag
+ * yet — while a seek still in flight half a second later has certainly set it. So
+ * a set flag means "keep waiting, the frame is coming" and a clear one means
+ * "nothing is coming, what is on the element is already the answer".
+ *
+ * The earlier version of this resolved unconditionally at the deadline, which
+ * turned a slow seek into a frame drawn before it arrived: the right timestamp
+ * with the previous picture. That is the failure this whole area has been bitten
+ * by repeatedly, and a busy decoder makes it reachable — screens are extracted
+ * immediately after 35 timeline thumbnails.
  */
-const SEEK_SETTLE_TIMEOUT_MS = 500;
+const SEEK_POLL_INTERVAL_MS = 500;
+
+/**
+ * Absolute cap on waiting for one seek.
+ *
+ * Rejects rather than drawing. Ten seconds of a seek not completing is a real
+ * failure, and guessing at the frame is how a wrong image ends up in a trace
+ * under a plausible timestamp — which reviewers then judge. Callers report it.
+ */
+const SEEK_ABSOLUTE_TIMEOUT_MS = 10000;
 
 /** Deadline for a thumbnail element to report metadata before giving up on it. */
 const THUMBNAIL_VIDEO_LOAD_TIMEOUT_MS = 20000;
@@ -76,10 +90,25 @@ const seekVideoToTime = async (video: HTMLVideoElement, t: number) => {
       cleanup();
       reject(e);
     };
-    timeout = window.setTimeout(() => {
+    const startedAt = performance.now();
+    const check = () => {
+      const waited = performance.now() - startedAt;
+      if (video.seeking && waited < SEEK_ABSOLUTE_TIMEOUT_MS) {
+        // A real seek is in flight. Resolving now would draw the frame it is
+        // replacing.
+        timeout = window.setTimeout(check, SEEK_POLL_INTERVAL_MS);
+        return;
+      }
       cleanup();
+      if (video.seeking) {
+        reject(
+          new Error(`Seek to ${t}s did not complete within ${waited | 0}ms`),
+        );
+        return;
+      }
       resolve();
-    }, SEEK_SETTLE_TIMEOUT_MS);
+    };
+    timeout = window.setTimeout(check, SEEK_POLL_INTERVAL_MS);
     video.addEventListener("seeked", onSeeked, { once: true });
     video.addEventListener("error", onError, { once: true });
     video.currentTime = t;

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
@@ -69,10 +69,41 @@ const SEEK_POLL_INTERVAL_MS = 500;
  */
 const SEEK_ABSOLUTE_TIMEOUT_MS = 10000;
 
+/**
+ * How far the element may sit from the requested moment and still count as the
+ * frame that was asked for. Roughly two frames at 30fps, which covers the snap to
+ * the nearest decodable frame.
+ */
+const SUPERSEDED_SEEK_TOLERANCE_SEC = 2 / 30;
+
 /** Deadline for a thumbnail element to report metadata before giving up on it. */
 const THUMBNAIL_VIDEO_LOAD_TIMEOUT_MS = 20000;
 
+/**
+ * Close enough to skip seeking altogether: the caller is asking for the position
+ * the element is already at. Deliberately far tighter than the superseded
+ * tolerance, which has to absorb frame snapping — this one must only fire when the
+ * request is genuinely the current position, so it never trades frame accuracy for
+ * speed.
+ */
+const ALREADY_AT_POSITION_SEC = 0.001;
+
 const seekVideoToTime = async (video: HTMLVideoElement, t: number) => {
+  // Nothing to wait for. `seeking` is checked because a seek already in flight
+  // means `currentTime` is somebody else's request, not where the element is —
+  // and that flag was set when their seek started, so reading it now is sound in
+  // a way that reading it straight after our own assignment would not be.
+  //
+  // Worth the special case: pressing `c` asks for exactly the current playhead,
+  // no seek starts, no `seeked` is ever coming, and without this the capture waits
+  // out the full poll interval before drawing a frame that was ready immediately.
+  if (
+    !video.seeking &&
+    Math.abs(video.currentTime - t) <= ALREADY_AT_POSITION_SEC
+  ) {
+    return;
+  }
+
   await new Promise<void>((resolve, reject) => {
     let timeout: number | null = null;
     const cleanup = () => {
@@ -121,9 +152,13 @@ const seekVideoToTime = async (video: HTMLVideoElement, t: number) => {
  * Two overlapping seeks on one element resolve on each other's `seeked` and leave
  * the decoder where neither caller asked, so the loser draws the winner's frame.
  * `extractVideoThumbnails` has always known this — "parallel messes up seeking" —
- * and runs its own loop sequentially, but the displayed element is read by three
- * callers that cannot see one another: `c` captures, the bootstrap screen pass,
- * and the scrub queue moving the playhead underneath both.
+ * and runs its own loop sequentially, but the displayed element is read by two
+ * callers that cannot see one another: `c` captures and the bootstrap screen pass.
+ *
+ * It does NOT cover the scrub queue, which writes `video.currentTime` directly and
+ * never comes through here. A drag can therefore retarget the element mid-read;
+ * `grabFrameViaCanvas` catches that afterwards by checking where the element
+ * actually ended up, rather than pretending this lock is enough.
  *
  * Keyed per element rather than globally, so a capture does not have to queue
  * behind ninety thumbnail extractions on a different element.
@@ -230,6 +265,23 @@ async function grabFrameViaCanvas(
   options: Required<ExtractVideoFrameOptions>
 ): Promise<FrameData> {
   await seekVideoToTime(video, t);
+  // Did somebody else move the playhead while this was waiting?
+  //
+  // The read queue only serializes extractions against each other. The scrub
+  // queue writes `video.currentTime` directly and is not in it, so a drag during
+  // a read retargets the element — and this seek's `seeked` handler may well be
+  // woken by the drag's seek instead of its own. Drawing then yields the frame
+  // the drag landed on, filed under the timestamp that was asked for.
+  //
+  // `currentTime` answers with the requested position, which is exactly what is
+  // wanted here: if it no longer reads as `t`, the request was replaced. The
+  // tolerance covers the element snapping to the nearest decodable frame once the
+  // seek completes.
+  if (Math.abs(video.currentTime - t) > SUPERSEDED_SEEK_TOLERANCE_SEC) {
+    throw new Error(
+      `Seek to ${t}s was superseded by a seek to ${video.currentTime}s`,
+    );
+  }
   const canvas = drawFrameToCanvas(
     video,
     options.scale,

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/repair-screen/util/ios-video-operations.ts
@@ -39,22 +39,81 @@ const resolveExtractOptions = (
   };
 };
 
+/**
+ * How long to wait for a seek to report back before drawing anyway.
+ *
+ * Asking for the position the element already holds may complete without firing
+ * `seeked` at all, and an unbounded wait there hangs the caller for good —
+ * capturing at the current playhead is exactly that case. Falling through is safe
+ * precisely when it happens, because the frame on the element is already the one
+ * being asked for.
+ *
+ * Deliberately a deadline rather than a `video.seeking` check. Skipping the wait
+ * whenever `seeking` reads false would draw before the frame arrives on any engine
+ * that sets the flag asynchronously, which trades a hang for a wrong frame — the
+ * far worse of the two, and the failure this whole area has already been bitten by.
+ */
+const SEEK_SETTLE_TIMEOUT_MS = 500;
+
+/** Deadline for a thumbnail element to report metadata before giving up on it. */
+const THUMBNAIL_VIDEO_LOAD_TIMEOUT_MS = 20000;
+
 const seekVideoToTime = async (video: HTMLVideoElement, t: number) => {
   await new Promise<void>((resolve, reject) => {
-    const onSeeked = () => {
+    let timeout: number | null = null;
+    const cleanup = () => {
+      if (timeout !== null) {
+        clearTimeout(timeout);
+      }
       video.removeEventListener("seeked", onSeeked);
       video.removeEventListener("error", onError);
+    };
+    const onSeeked = () => {
+      cleanup();
       resolve();
     };
     const onError = (e: Event) => {
-      video.removeEventListener("seeked", onSeeked);
-      video.removeEventListener("error", onError);
+      cleanup();
       reject(e);
     };
+    timeout = window.setTimeout(() => {
+      cleanup();
+      resolve();
+    }, SEEK_SETTLE_TIMEOUT_MS);
     video.addEventListener("seeked", onSeeked, { once: true });
     video.addEventListener("error", onError, { once: true });
     video.currentTime = t;
   });
+};
+
+/**
+ * One read at a time per element.
+ *
+ * Two overlapping seeks on one element resolve on each other's `seeked` and leave
+ * the decoder where neither caller asked, so the loser draws the winner's frame.
+ * `extractVideoThumbnails` has always known this — "parallel messes up seeking" —
+ * and runs its own loop sequentially, but the displayed element is read by three
+ * callers that cannot see one another: `c` captures, the bootstrap screen pass,
+ * and the scrub queue moving the playhead underneath both.
+ *
+ * Keyed per element rather than globally, so a capture does not have to queue
+ * behind ninety thumbnail extractions on a different element.
+ */
+const readQueues = new WeakMap<HTMLVideoElement, Promise<unknown>>();
+
+const enqueueRead = <T,>(
+  video: HTMLVideoElement,
+  operation: () => Promise<T>
+): Promise<T> => {
+  const previous = readQueues.get(video) ?? Promise.resolve();
+  const run = previous.then(operation, operation);
+  // Swallowed for the chain's benefit only: a failed read must not block the
+  // reads behind it. The caller still sees the rejection through `run`.
+  readQueues.set(
+    video,
+    run.catch(() => undefined)
+  );
+  return run;
 };
 
 const drawFrameToCanvas = (
@@ -174,7 +233,7 @@ export async function extractVideoFrame(
   overrideOptions?: ExtractVideoFrameOptions
 ): Promise<FrameData> {
   const options = resolveExtractOptions(scaleOrOptions, overrideOptions);
-  return grabFrameViaCanvas(video, t, options);
+  return enqueueRead(video, () => grabFrameViaCanvas(video, t, options));
 }
 
 /**
@@ -195,12 +254,65 @@ export async function extractVideoThumbnails(
   const thumbVideo = document.createElement("video");
   thumbVideo.crossOrigin = "anonymous";
   thumbVideo.preload = "metadata";
-  thumbVideo.src = video.src;
-  await new Promise<void>((res) =>
-    thumbVideo.addEventListener("loadedmetadata", () => res(), {
-      once: true,
-    })
-  );
+  thumbVideo.src = video.currentSrc || video.src;
+  try {
+    // Rejects rather than waiting forever. With no error path and no deadline
+    // this promise could simply never settle — an element that never gets
+    // metadata never fires the event — and the caller was left with an empty
+    // thumbnail grid, no toast, and nothing in the console. A scrub with no
+    // preview and no badge is what that looks like from the outside, and it had
+    // to be diagnosed from behaviour because nothing reported it.
+    await new Promise<void>((resolve, reject) => {
+      let timeout: number | null = null;
+      const cleanup = () => {
+        if (timeout !== null) {
+          clearTimeout(timeout);
+        }
+        thumbVideo.removeEventListener("loadedmetadata", onLoaded);
+        thumbVideo.removeEventListener("error", onError);
+      };
+      const onLoaded = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = () => {
+        cleanup();
+        reject(new Error("Thumbnail video failed to load"));
+      };
+      timeout = window.setTimeout(() => {
+        cleanup();
+        reject(new Error("Thumbnail video load timed out"));
+      }, THUMBNAIL_VIDEO_LOAD_TIMEOUT_MS);
+      thumbVideo.addEventListener("loadedmetadata", onLoaded, { once: true });
+      thumbVideo.addEventListener("error", onError, { once: true });
+    });
+    return await extractThumbnailsFrom(
+      thumbVideo,
+      video,
+      videoDuration,
+      maxThumbs,
+      thumbHeight,
+      options
+    );
+  } finally {
+    // Releases the element's hold on the resource. Whether a detached media
+    // element with a loaded source is collected promptly is engine-dependent, so
+    // this is hygiene rather than a measured fix — but browsers do cap how many
+    // videos they decode at once, and two of these were created per bootstrap
+    // and never let go.
+    thumbVideo.removeAttribute("src");
+    thumbVideo.load();
+  }
+}
+
+async function extractThumbnailsFrom(
+  thumbVideo: HTMLVideoElement,
+  video: HTMLVideoElement,
+  videoDuration: number,
+  maxThumbs: number,
+  thumbHeight: number,
+  options?: ExtractVideoFrameOptions
+): Promise<ListedFiles[]> {
   // determine how many thumbnails to extract
   const duration = videoDuration;
   const fps = 60;

--- a/src/app/(signed-in)/capture/[captureId]/edit/components/types.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/components/types.ts
@@ -85,20 +85,12 @@ export const GestureSchema = z
     },
   );
 
-export const ScreenGestureSchema = z
-  .object({
-    screens: ScreenSchema,
-    gestures: GestureSchema,
-  })
-  .refine(
-    (data) => {
-      // Check all screens except the last one have gestures
-      return data.screens.slice(0, -1).every((screen) => {
-        return data.gestures[screen.id];
-      });
-    },
-    { message: "Each screen except the last one must have a gesture" },
-  );
+// Screen-annotation completeness is not a schema. Layering `.refine` on top of
+// field validation under-reports, because zod skips a refine once the schema
+// beneath it fails, so a screen missing its marker hid every screen missing its
+// gesture entirely. It lives in `getScreenAnnotationIssue`
+// (repair-screen/util/gesture-description-template.ts), which both the
+// filmstrip's error ring and the step gates in page.tsx call.
 
 export const RedactionSchema = z
   .record(

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -78,6 +78,55 @@ const FEEDBACK_STEP_ORDER = [
   TraceSteps.Review,
 ];
 
+type IncompleteScreen = {
+  screenNumber: number;
+  issue: ScreenAnnotationIssue;
+};
+
+/**
+ * Screens whose annotation is unfinished, numbered the way the filmstrip numbers
+ * them. The last screen is the goal state and needs no gesture.
+ *
+ * Scanned per screen rather than parsed with a zod schema. Zod skips a `.refine`
+ * when the schema beneath it failed, and the ways an annotation can be
+ * incomplete sit at different levels — a missing marker fails field validation,
+ * unfilled template slots fail a refine, a screen with no gesture at all fails a
+ * different refine — so any field-level failure hid the rest. Both gates share
+ * this function so they cannot drift apart or under-report.
+ */
+function collectIncompleteScreens(
+  screens: TraceFormData["screens"],
+  gestures: TraceFormData["gestures"],
+): IncompleteScreen[] {
+  return screens
+    .slice(0, -1)
+    .map((screen, index) => ({
+      screenNumber: index + 1,
+      issue: getScreenAnnotationIssue(gestures[screen.id]),
+    }))
+    .filter((entry): entry is IncompleteScreen => entry.issue !== null);
+}
+
+/**
+ * One message saying what each unfinished screen needs. Past four screens the
+ * reasons stop fitting a toast, so it falls back to numbers and points at the
+ * filmstrip, which rings exactly the same set.
+ */
+function describeIncompleteScreens(entries: IncompleteScreen[]): string {
+  const describe = (entry: IncompleteScreen) =>
+    `Screen ${entry.screenNumber}: ${SCREEN_ANNOTATION_ISSUE_ACTIONS[entry.issue]}`;
+
+  if (entries.length === 1) {
+    return `${describe(entries[0])}.`;
+  }
+  if (entries.length <= 4) {
+    return `${entries.length} screens need work — ${entries.map(describe).join("; ")}.`;
+  }
+  return `${entries.length} screens need work: ${entries
+    .map((entry) => entry.screenNumber)
+    .join(", ")}. The filmstrip rings them in yellow.`;
+}
+
 export default function Page() {
   const CHECKLIST_LAYOUT_STORAGE_KEY = "edit-feedback-checklist-layout";
   const params = useParams();
@@ -574,61 +623,14 @@ export default function Page() {
     setIsSubmitting(true);
     // check zod schema validation for each step
     if (stepIndex === TraceSteps.Capture) {
-      // Scanned per screen rather than run through ScreenGestureSchema. Zod skips
-      // a `.refine` when the schema beneath it already failed, and the three ways
-      // an annotation can be incomplete sit at three different levels: a missing
-      // marker fails field validation, an unfilled template fails
-      // GestureSchema's refine, and a screen with no gesture at all fails
-      // ScreenGestureSchema's refine. Any field-level failure therefore silenced
-      // the other two, so a worker fixed one screen, pressed Next, and only then
-      // discovered the next problem.
-      //
-      // isScreenAnnotationComplete is the same predicate the filmstrip uses for
-      // its error ring, so what is flagged here is what is ringed there.
       const { screens: currentScreens, gestures: currentGestures } =
         methods.getValues();
-      // The last screen is the goal state and needs no gesture.
-      const incompleteScreens = currentScreens
-        .slice(0, -1)
-        .map((screen, index) => ({
-          screenNumber: index + 1,
-          issue: getScreenAnnotationIssue(currentGestures[screen.id]),
-        }))
-        .filter(
-          (
-            entry,
-          ): entry is { screenNumber: number; issue: ScreenAnnotationIssue } =>
-            entry.issue !== null,
-        );
-
+      const incompleteScreens = collectIncompleteScreens(
+        currentScreens,
+        currentGestures,
+      );
       if (incompleteScreens.length > 0) {
-        // Say what to do, not just where. Listing bare screen numbers moves the
-        // guesswork rather than removing it. Beyond a handful the per-screen
-        // reasons stop fitting in a toast, so fall back to the numbers and point
-        // at the filmstrip, which rings exactly these screens.
-        const describe = ({
-          screenNumber,
-          issue,
-        }: {
-          screenNumber: number;
-          issue: ScreenAnnotationIssue;
-        }) => `Screen ${screenNumber}: ${SCREEN_ANNOTATION_ISSUE_ACTIONS[issue]}`;
-
-        if (incompleteScreens.length === 1) {
-          toast.error(`${describe(incompleteScreens[0])}.`);
-        } else if (incompleteScreens.length <= 4) {
-          toast.error(
-            `${incompleteScreens.length} screens need work — ${incompleteScreens
-              .map(describe)
-              .join("; ")}.`,
-          );
-        } else {
-          toast.error(
-            `${incompleteScreens.length} screens need work: ${incompleteScreens
-              .map((entry) => entry.screenNumber)
-              .join(", ")}. The filmstrip rings them in yellow.`,
-          );
-        }
+        toast.error(describeIncompleteScreens(incompleteScreens));
         setIsSubmitting(false);
         return;
       }
@@ -647,26 +649,42 @@ export default function Page() {
         return;
       }
     } else if (stepIndex === TraceSteps.Review) {
-      // validate all screen gestures except the last one
-      const allButLastScreenIds = methods
-        .getValues()
-        .screens.slice(0, -1)
-        .map((s) => s.id);
+      const { screens: currentScreens, gestures: currentGestures } =
+        methods.getValues();
+      // Gestures first, with the same predicate and reporting as the capture
+      // step. TraceFormSchema's refines under-report for the reason described on
+      // collectIncompleteScreens, and this is the gate that decides whether a
+      // trace reaches a reviewer — a screen captured after passing the capture
+      // step would otherwise slip through unannotated.
+      const incompleteScreens = collectIncompleteScreens(
+        currentScreens,
+        currentGestures,
+      );
+      if (incompleteScreens.length > 0) {
+        toast.error(describeIncompleteScreens(incompleteScreens));
+        setIsSubmitting(false);
+        return;
+      }
+
+      // Then the rest of the trace — the description above all, which is only
+      // written at this step.
+      const allButLastScreenIds = currentScreens.slice(0, -1).map((s) => s.id);
       const allButLastScreenGestures = Object.fromEntries(
-        Object.entries(methods.getValues().gestures).filter(([id, _]) =>
+        Object.entries(currentGestures).filter(([id]) =>
           allButLastScreenIds.includes(id),
         ),
       );
-      // Validate the entire trace form, especially "description"
       const validation = TraceFormSchema.safeParse({
         ...methods.getValues(),
         gestures: allButLastScreenGestures,
       });
       if (!validation.success) {
-        const errors = validation.error.issues || "Invalid input";
-        errors.forEach((error) => {
-          toast.error(error.message);
-        });
+        console.error(validation.error.issues);
+        // Deduplicated: the schema reports per field, so one cause can surface
+        // several times with the same wording.
+        new Set(validation.error.issues.map((issue) => issue.message)).forEach(
+          (message) => toast.error(message),
+        );
         setIsSubmitting(false);
         return;
       }

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -22,7 +22,11 @@ import {
   TraceFormData,
   TraceFormSchema,
 } from "./components/types";
-import { isScreenAnnotationComplete } from "./components/repair-screen/util";
+import {
+  SCREEN_ANNOTATION_ISSUE_ACTIONS,
+  ScreenAnnotationIssue,
+  getScreenAnnotationIssue,
+} from "./components/repair-screen/util";
 
 import { Button } from "@/components/ui/button";
 import Sheet from "./components/sheet";
@@ -584,21 +588,47 @@ export default function Page() {
       const { screens: currentScreens, gestures: currentGestures } =
         methods.getValues();
       // The last screen is the goal state and needs no gesture.
-      const incompleteScreenNumbers = currentScreens
+      const incompleteScreens = currentScreens
         .slice(0, -1)
-        .map((screen, index) => ({ screen, screenNumber: index + 1 }))
+        .map((screen, index) => ({
+          screenNumber: index + 1,
+          issue: getScreenAnnotationIssue(currentGestures[screen.id]),
+        }))
         .filter(
-          ({ screen }) =>
-            !isScreenAnnotationComplete(currentGestures[screen.id]),
-        )
-        .map(({ screenNumber }) => screenNumber);
-
-      if (incompleteScreenNumbers.length > 0) {
-        toast.error(
-          incompleteScreenNumbers.length === 1
-            ? `Screen ${incompleteScreenNumbers[0]} needs a gesture, a marker on the screen, and a complete description.`
-            : `${incompleteScreenNumbers.length} screens still need work: ${incompleteScreenNumbers.join(", ")}.`,
+          (
+            entry,
+          ): entry is { screenNumber: number; issue: ScreenAnnotationIssue } =>
+            entry.issue !== null,
         );
+
+      if (incompleteScreens.length > 0) {
+        // Say what to do, not just where. Listing bare screen numbers moves the
+        // guesswork rather than removing it. Beyond a handful the per-screen
+        // reasons stop fitting in a toast, so fall back to the numbers and point
+        // at the filmstrip, which rings exactly these screens.
+        const describe = ({
+          screenNumber,
+          issue,
+        }: {
+          screenNumber: number;
+          issue: ScreenAnnotationIssue;
+        }) => `Screen ${screenNumber}: ${SCREEN_ANNOTATION_ISSUE_ACTIONS[issue]}`;
+
+        if (incompleteScreens.length === 1) {
+          toast.error(`${describe(incompleteScreens[0])}.`);
+        } else if (incompleteScreens.length <= 4) {
+          toast.error(
+            `${incompleteScreens.length} screens need work — ${incompleteScreens
+              .map(describe)
+              .join("; ")}.`,
+          );
+        } else {
+          toast.error(
+            `${incompleteScreens.length} screens need work: ${incompleteScreens
+              .map((entry) => entry.screenNumber)
+              .join(", ")}. The filmstrip rings them in yellow.`,
+          );
+        }
         setIsSubmitting(false);
         return;
       }

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -297,6 +297,15 @@ export default function Page() {
       const draftFileResponse = await fetch(
         signedLatestDraftFileRes.data.signedUrl,
       );
+      // Checked, because an error response body is not draft JSON and parsing it
+      // throws somewhere far less obvious than here.
+      if (!draftFileResponse.ok) {
+        setDraftFetchResult(DraftFetchResults.ERROR);
+        console.error(
+          `Failed to download draft file: ${draftFileResponse.status}`,
+        );
+        return;
+      }
       const draftFormData: DraftTraceFormData = await draftFileResponse.json();
 
       // Check if we already have screens with src data to avoid overwriting
@@ -338,7 +347,17 @@ export default function Page() {
       }
       setDraftFetchResult(DraftFetchResults.SUCCESS);
     };
-    fetchFiles();
+    // Every early return above reports failure, but a *thrown* failure had
+    // nowhere to go: `fetch` rejects on a network error rather than returning
+    // something falsy, and `.json()` throws on a body that is not JSON. Either
+    // escaped as an unhandled rejection, so the state never left LOADING and the
+    // editor sat on "Loading saved draft data..." for good — with the error state
+    // it needed already built and wired to a message telling the worker what to
+    // do about it.
+    fetchFiles().catch((error) => {
+      setDraftFetchResult(DraftFetchResults.ERROR);
+      console.error(`Failed to load draft data: ${error}`);
+    });
   }, [captureId, draftFetchResult, methods]);
 
   // Fetch video files once when component mounts - files won't change during edit session

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -19,10 +19,10 @@ import { toast } from "sonner";
 import {
   DraftTraceFormData,
   RedactionSchema,
-  ScreenGestureSchema,
   TraceFormData,
   TraceFormSchema,
 } from "./components/types";
+import { isScreenAnnotationComplete } from "./components/repair-screen/util";
 
 import { Button } from "@/components/ui/button";
 import Sheet from "./components/sheet";
@@ -570,59 +570,35 @@ export default function Page() {
     setIsSubmitting(true);
     // check zod schema validation for each step
     if (stepIndex === TraceSteps.Capture) {
-      // validate all screen gestures except the last one
-      const allButLastScreenIds = methods
-        .getValues()
-        .screens.slice(0, -1)
-        .map((s) => s.id);
-      const allButLastScreenGestures = Object.fromEntries(
-        Object.entries(methods.getValues().gestures).filter(([id, _]) =>
-          allButLastScreenIds.includes(id),
-        ),
-      );
-      // Validate the "gestures"
-      const validation = ScreenGestureSchema.safeParse({
-        ...methods.getValues(),
-        gestures: allButLastScreenGestures,
-      });
-      if (!validation.success) {
-        console.error(validation.error.issues);
-        // Group by screen. GestureSchema validates each field separately, so one
-        // untouched gesture yields three or four issues — "Gesture type is
-        // required", "X coordinate is required", "Y coordinate is required" —
-        // which fired as separate toasts and told the worker neither which
-        // screen to fix nor that "X coordinate" means "place the marker".
-        const currentScreens = methods.getValues().screens;
-        const screenNumberById = new Map(
-          currentScreens.map((screen, index) => [screen.id, index + 1]),
+      // Scanned per screen rather than run through ScreenGestureSchema. Zod skips
+      // a `.refine` when the schema beneath it already failed, and the three ways
+      // an annotation can be incomplete sit at three different levels: a missing
+      // marker fails field validation, an unfilled template fails
+      // GestureSchema's refine, and a screen with no gesture at all fails
+      // ScreenGestureSchema's refine. Any field-level failure therefore silenced
+      // the other two, so a worker fixed one screen, pressed Next, and only then
+      // discovered the next problem.
+      //
+      // isScreenAnnotationComplete is the same predicate the filmstrip uses for
+      // its error ring, so what is flagged here is what is ringed there.
+      const { screens: currentScreens, gestures: currentGestures } =
+        methods.getValues();
+      // The last screen is the goal state and needs no gesture.
+      const incompleteScreenNumbers = currentScreens
+        .slice(0, -1)
+        .map((screen, index) => ({ screen, screenNumber: index + 1 }))
+        .filter(
+          ({ screen }) =>
+            !isScreenAnnotationComplete(currentGestures[screen.id]),
+        )
+        .map(({ screenNumber }) => screenNumber);
+
+      if (incompleteScreenNumbers.length > 0) {
+        toast.error(
+          incompleteScreenNumbers.length === 1
+            ? `Screen ${incompleteScreenNumbers[0]} needs a gesture, a marker on the screen, and a complete description.`
+            : `${incompleteScreenNumbers.length} screens still need work: ${incompleteScreenNumbers.join(", ")}.`,
         );
-        const flaggedScreenNumbers = new Set<number>();
-        const otherMessages = new Set<string>();
-
-        validation.error.issues.forEach((issue) => {
-          const [field, screenId] = issue.path;
-          if (field === "gestures" && typeof screenId === "string") {
-            const screenNumber = screenNumberById.get(screenId);
-            if (screenNumber !== undefined) {
-              flaggedScreenNumbers.add(screenNumber);
-              return;
-            }
-          }
-          otherMessages.add(issue.message);
-        });
-
-        if (flaggedScreenNumbers.size > 0) {
-          const screenList = Array.from(flaggedScreenNumbers).sort(
-            (a, b) => a - b,
-          );
-          toast.error(
-            screenList.length === 1
-              ? `Screen ${screenList[0]} needs a gesture with a description.`
-              : `These screens need a gesture with a description: ${screenList.join(", ")}.`,
-          );
-        }
-        otherMessages.forEach((message) => toast.error(message));
-
         setIsSubmitting(false);
         return;
       }

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -36,7 +36,12 @@ import RedactScreen from "./components/redact-screen";
 import { RedactScreenJumpTarget } from "./components/redact-screen/redact-screen";
 import RedactDoc from "./components/redact-screen/doc.mdx";
 
-import { DraftFetchResults, getDraftFiles, handleDraftSave } from "./util";
+import {
+  DraftFetchResults,
+  dedupeScreensById,
+  getDraftFiles,
+  handleDraftSave,
+} from "./util";
 import { revalidateCaptureCaches, updateCapture } from "@/lib/actions";
 import { CaptureStatus } from "@prisma/client";
 import { generateSignedCloudFrontURL } from "@/lib/aws/s3/server";
@@ -208,10 +213,13 @@ export default function Page() {
       }
 
       if (!hasScreensWithSrc) {
+        // Screen id keys selection, gestures, redactions and VHs, so a repeated
+        // id in a draft would make all four ambiguous.
+        const draftScreens = dedupeScreensById(draftFormData.screens);
         // grab screens
         methods.setValue(
           "screens",
-          draftFormData.screens.map((screen) => ({
+          draftScreens.map((screen) => ({
             id: screen.id,
             src: "",
             timestamp: screen.timestamp,
@@ -219,7 +227,7 @@ export default function Page() {
         );
         // grab vh from android screens
         const draftVHs: { [key: string]: any } = {};
-        draftFormData.screens.forEach((screen) => {
+        draftScreens.forEach((screen) => {
           draftVHs[screen.id] = null;
         });
         methods.setValue("vhs", draftVHs);

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -42,6 +42,7 @@ import RedactDoc from "./components/redact-screen/doc.mdx";
 
 import {
   DraftFetchResults,
+  countUnlabelledRedactions,
   dedupeScreensById,
   getDraftFiles,
   handleDraftSave,
@@ -105,6 +106,56 @@ function collectIncompleteScreens(
       issue: getScreenAnnotationIssue(gestures[screen.id]),
     }))
     .filter((entry): entry is IncompleteScreen => entry.issue !== null);
+}
+
+type UnlabelledRedactionScreen = {
+  screenNumber: number;
+  boxCount: number;
+};
+
+/**
+ * Screens carrying redaction boxes with no label, numbered the way the filmstrip
+ * numbers them.
+ *
+ * Scanned rather than parsed for the same reason as `collectIncompleteScreens`:
+ * `RedactionSchema`'s refine returns on the first unlabelled box and reports one
+ * record-level message, so it can say neither which screen nor how many boxes.
+ *
+ * Slightly stricter than the schema, which only rejects an empty string — a
+ * whitespace-only label is no more useful to a reviewer than a blank one.
+ */
+function collectUnlabelledRedactions(
+  screens: TraceFormData["screens"],
+  redactions: TraceFormData["redactions"],
+): UnlabelledRedactionScreen[] {
+  return screens
+    .map((screen, index) => ({
+      screenNumber: index + 1,
+      boxCount: countUnlabelledRedactions(redactions[screen.id]),
+    }))
+    .filter((entry) => entry.boxCount > 0);
+}
+
+/** One message naming the screens whose redaction boxes still need labels. */
+function describeUnlabelledRedactions(
+  entries: UnlabelledRedactionScreen[],
+): string {
+  const describe = (entry: UnlabelledRedactionScreen) =>
+    `Screen ${entry.screenNumber}: label ${
+      entry.boxCount === 1
+        ? "the redaction box"
+        : `${entry.boxCount} redaction boxes`
+    }`;
+
+  if (entries.length === 1) {
+    return `${describe(entries[0])}.`;
+  }
+  if (entries.length <= 4) {
+    return `${entries.length} screens need work — ${entries.map(describe).join("; ")}.`;
+  }
+  return `${entries.length} screens have unlabelled redaction boxes: ${entries
+    .map((entry) => entry.screenNumber)
+    .join(", ")}.`;
 }
 
 /**
@@ -635,16 +686,29 @@ export default function Page() {
         return;
       }
     } else if (stepIndex === TraceSteps.Redact) {
-      // Validate the "redactions"
-      const validation = RedactionSchema.safeParse(
-        methods.getValues().redactions,
+      const { screens: currentScreens, redactions: currentRedactions } =
+        methods.getValues();
+      // Unlabelled boxes first, named per screen. The schema can only say "each
+      // redaction must have an annotation", which leaves the worker opening
+      // screens one by one to find out where.
+      const unlabelledRedactions = collectUnlabelledRedactions(
+        currentScreens,
+        currentRedactions,
       );
+      if (unlabelledRedactions.length > 0) {
+        toast.error(describeUnlabelledRedactions(unlabelledRedactions));
+        setIsSubmitting(false);
+        return;
+      }
+
+      // Then the structural check, for anything malformed the UI should not be
+      // able to produce.
+      const validation = RedactionSchema.safeParse(currentRedactions);
       if (!validation.success) {
         console.error(validation.error.issues);
-        const errors = validation.error.issues || "Invalid input";
-        errors.forEach((error) => {
-          toast.error(error.message);
-        });
+        new Set(validation.error.issues.map((issue) => issue.message)).forEach(
+          (message) => toast.error(message),
+        );
         setIsSubmitting(false);
         return;
       }

--- a/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
+++ b/src/app/(signed-in)/capture/[captureId]/edit/page.tsx
@@ -587,10 +587,42 @@ export default function Page() {
       });
       if (!validation.success) {
         console.error(validation.error.issues);
-        const errors = validation.error.issues || "Invalid input";
-        errors.forEach((error) => {
-          toast.error(error.message);
+        // Group by screen. GestureSchema validates each field separately, so one
+        // untouched gesture yields three or four issues — "Gesture type is
+        // required", "X coordinate is required", "Y coordinate is required" —
+        // which fired as separate toasts and told the worker neither which
+        // screen to fix nor that "X coordinate" means "place the marker".
+        const currentScreens = methods.getValues().screens;
+        const screenNumberById = new Map(
+          currentScreens.map((screen, index) => [screen.id, index + 1]),
+        );
+        const flaggedScreenNumbers = new Set<number>();
+        const otherMessages = new Set<string>();
+
+        validation.error.issues.forEach((issue) => {
+          const [field, screenId] = issue.path;
+          if (field === "gestures" && typeof screenId === "string") {
+            const screenNumber = screenNumberById.get(screenId);
+            if (screenNumber !== undefined) {
+              flaggedScreenNumbers.add(screenNumber);
+              return;
+            }
+          }
+          otherMessages.add(issue.message);
         });
+
+        if (flaggedScreenNumbers.size > 0) {
+          const screenList = Array.from(flaggedScreenNumbers).sort(
+            (a, b) => a - b,
+          );
+          toast.error(
+            screenList.length === 1
+              ? `Screen ${screenList[0]} needs a gesture with a description.`
+              : `These screens need a gesture with a description: ${screenList.join(", ")}.`,
+          );
+        }
+        otherMessages.forEach((message) => toast.error(message));
+
         setIsSubmitting(false);
         return;
       }

--- a/src/app/(signed-in)/capture/[captureId]/edit/util/dedupe-screens.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/util/dedupe-screens.ts
@@ -1,0 +1,28 @@
+/**
+ * Drops screens whose id has already been seen, keeping the first occurrence.
+ *
+ * Screen id is the key for selection, gestures, redactions and view hierarchies,
+ * so a duplicate makes all four ambiguous: two filmstrip entries highlight as
+ * selected at once, and deleting one removes whichever matches first rather than
+ * the one that was clicked. Position used to disambiguate this; identity does
+ * not. Drafts are external JSON written by earlier versions of the editor, so
+ * the invariant is enforced on the way in rather than assumed.
+ *
+ * @param screens - Screens as loaded from a draft or capture metadata file.
+ * @returns The same screens in order, minus later entries repeating an id.
+ */
+export function dedupeScreensById<T extends { id: string }>(
+  screens: T[],
+): T[] {
+  const seenIds = new Set<string>();
+  return screens.filter((screen) => {
+    if (seenIds.has(screen.id)) {
+      console.warn(
+        `Dropping screen with duplicate id "${screen.id}" while loading draft.`,
+      );
+      return false;
+    }
+    seenIds.add(screen.id);
+    return true;
+  });
+}

--- a/src/app/(signed-in)/capture/[captureId]/edit/util/index.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/util/index.ts
@@ -1,2 +1,3 @@
 export * from "./export";
 export * from "./vh-parse";
+export * from "./dedupe-screens";

--- a/src/app/(signed-in)/capture/[captureId]/edit/util/index.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/util/index.ts
@@ -1,3 +1,4 @@
 export * from "./export";
 export * from "./vh-parse";
 export * from "./dedupe-screens";
+export * from "./redaction-completeness";

--- a/src/app/(signed-in)/capture/[captureId]/edit/util/redaction-completeness.ts
+++ b/src/app/(signed-in)/capture/[captureId]/edit/util/redaction-completeness.ts
@@ -1,0 +1,28 @@
+/** A redaction box only needs its label for these checks. */
+type LabelledRedaction = { annotation?: string | null };
+
+/**
+ * Whether a redaction box carries a usable label.
+ *
+ * Stricter than `RedactionSchema`, which only rejects an empty string: a
+ * whitespace-only label is no more useful to a reviewer than a blank one.
+ */
+export function isRedactionLabelled(redaction: LabelledRedaction): boolean {
+  return (redaction.annotation ?? "").trim().length > 0;
+}
+
+/**
+ * How many of a screen's redaction boxes still need a label.
+ *
+ * Shared by the redact filmstrip's error ring and the step gate in page.tsx so
+ * the screens flagged in one are exactly the screens named by the other.
+ *
+ * @param redactions - A screen's redaction boxes, if it has any.
+ */
+export function countUnlabelledRedactions(
+  redactions: LabelledRedaction[] | undefined,
+): number {
+  return (redactions ?? []).filter(
+    (redaction) => !isRedactionLabelled(redaction),
+  ).length;
+}


### PR DESCRIPTION
Two rounds of work on the annotate step, already merged to `odim-dev-env` (#189, #190, #191) and QA'd against the dev deployment in Chrome on both iOS and Android captures.

## Worker-facing fixes

The original report was that annotating a screen added mid-trace would jump to a different screen on every keystroke. That turned out to be four separate faults:

- Every `setValue` handed `useWatch` a fresh deep clone, so the effect that syncs focus re-ran on each keystroke and reset selection
- `c` fired while typing in a form field, capturing a phantom screen
- The completeness guard trapped keyboard navigation
- Screen selection was keyed by array position, so any reorder moved focus

Selection is now keyed by screen id, with one owner for selection and the playhead. Alongside that:

- Validation names every incomplete screen and what each one needs, for gestures and redactions both, instead of reporting one field at a time
- Duplicate screen ids in a draft are dropped, since a repeated id made selection, gestures, redactions and VHs all ambiguous
- Focus follows a screen as soon as it is captured
- The scrub preview is labelled, so the correction when the exact frame arrives reads as sharpening rather than the tool changing its mind
- The real frame appears while a drag is held still, rather than waiting for mouse-up
- No video flash while `,`/`.` are held, or when the real frame is uncovered

## Reliability

- Frame reads are serialized per element. Two overlapping seeks on one element resolve on each other's `seeked` and leave the decoder where neither caller asked
- A seek is bounded and never draws a frame it has not received. Past ten seconds it reports rather than guessing, because a plausible-looking wrong frame is worse than a visible failure
- A failed frame read can no longer truncate the screen list. It previously left the list cut short at the failing screen — and autosave, which runs every three minutes without inspecting form state, would write that over the worker's draft and take the rest of their annotation work with it
- A failed draft load reports itself instead of sitting on "Loading saved draft data…" indefinitely. The error state already existed and was simply unreachable
- Thumbnail extraction releases the media element it creates, and reports failure instead of hanging on a `loadedmetadata` that never arrives

## Performance

Bootstrap no longer blocks the step on scrub-preview extraction: roughly 6.8s to 3.6s before the step is interactive. Preview thumbnails arrive shortly after, so a very early scrub may briefly have no preview.

Also includes a flag-gated scrub profiler, off unless enabled with `?scrubProfiling=1`.

## Known, and not fixed here

Safari can still show the wrong settled frame, and `c` can capture it — right timestamp, picture from elsewhere in the recording. The cause is [WebKit 153588](https://bugs.webkit.org/show_bug.cgi?id=153588), open since 2016: `drawImage` on a video element returns one frame regardless of `currentTime`, intermittently. It predates this work and is not made worse by it. Workers have been directed to Chrome during onboarding.

Chrome is measurably unaffected: its element path agreed with an independent decoder at all sampled timestamps, and `requestVideoFrameCallback` fires there for paused seeks where Safari never fires it.

The investigation — evidence, four dead ends and why each looked convincing, and a validated ffmpeg.wasm replacement path — is on the `safari-frame-investigation` branch under `docs/investigations/`. Two follow-ups are recorded there: whether already-captured screens need auditing, since Safari wrote wrong images under correct timestamps that reviewers then judged, and `dedupeScreensById` not yet covering Android's `original-metadata.json` path.

## Testing

- Chrome, dev deployment: capture both stationary and immediately after a scrub, preview badge, mid-drag reveal, `,`/`.` held without flashing, `j`/`k`/`l`, keyboard navigation past the scrubber, and the Android focus view
- `type-check`, `lint` and a production build clean on the merged content
- Two new failure paths are unexercised — a superseded read, and screens that cannot be rebuilt. Both were checked by reading the control flow rather than triggered; the worst case in either direction is a placeholder tile plus a toast, with annotations left intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
